### PR TITLE
fix: deployment-ready Helm chart

### DIFF
--- a/charts/roundtable/templates/knight/deployment.yaml
+++ b/charts/roundtable/templates/knight/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
   namespace: {{ $.Values.namespace }}
   labels:
     {{- include "roundtable.knightLabels" (dict "ctx" $ "name" $name "knight" $knight) | nindent 4 }}
+  annotations:
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   selector:
@@ -18,36 +20,72 @@ spec:
       labels:
         {{- include "roundtable.knightLabels" (dict "ctx" $ "name" $name "knight" $knight) | nindent 8 }}
     spec:
+      shareProcessNamespace: true
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
       containers:
         # ── OpenClaw Gateway ──────────────────────────────────────────
         - name: openclaw
-          image: {{ $knight.openclaw.image | default "ghcr.io/anthropics/openclaw:latest" }}
+          image: "{{ $.Values.openclaw.image.repository }}:{{ $.Values.openclaw.image.tag }}"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              {{- $.Values.openclaw.command | nindent 14 }}
           ports:
             - name: openclaw
-              containerPort: {{ $knight.openclaw.port | default 18789 }}
+              containerPort: {{ $.Values.openclaw.port }}
           env:
+            - name: TZ
+              value: America/Chicago
+            - name: HOME
+              value: /home/node
+            - name: TERM
+              value: xterm-256color
+            - name: PATH
+              value: /home/node/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
             - name: KNIGHT_NAME
               value: {{ $name }}
             - name: KNIGHT_DOMAIN
               value: {{ $knight.domain }}
             - name: KNIGHT_FLEET
               value: {{ $knight.fleetId }}
-            - name: KNIGHT_MODEL
-              value: {{ $knight.model | default "anthropic/claude-sonnet-4-5" }}
+            {{- if $knight.chrome | default dict | dig "enabled" false }}
+            - name: BROWSER_WS_ENDPOINT
+              value: "ws://localhost:9222"
+            {{- end }}
+            # Gateway token from ExternalSecret
+            - name: CLAWDBOT_GATEWAY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: roundtable-secrets
+                  key: {{ $knight.gatewayTokenKey | default (printf "ROUNDTABLE_%s_GATEWAY_TOKEN" ($name | upper)) }}
+            # API key from ExternalSecret
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: roundtable-secrets
+                  key: ROUNDTABLE_ANTHROPIC_API_KEY
           volumeMounts:
             - name: workspace
-              mountPath: /home/node/workspace
+              mountPath: /home/node/{{ $name }}
             - name: workspace-config
-              mountPath: /home/node/workspace/SOUL.md
+              mountPath: /home/node/{{ $name }}/SOUL.md
               subPath: SOUL.md
             - name: workspace-config
-              mountPath: /home/node/workspace/AGENTS.md
+              mountPath: /home/node/{{ $name }}/AGENTS.md
               subPath: AGENTS.md
             - name: workspace-config
-              mountPath: /home/node/workspace/TOOLS.md
+              mountPath: /home/node/{{ $name }}/TOOLS.md
               subPath: TOOLS.md
+            - name: openclaw-config
+              mountPath: /home/node/.openclaw/openclaw.json
+              subPath: openclaw.json
             - name: skills
-              mountPath: /home/node/workspace/skills
+              mountPath: /home/node/{{ $name }}/skills
               readOnly: true
           {{- with $knight.resources }}
           resources:
@@ -56,15 +94,15 @@ spec:
 
         # ── NATS Bridge Sidecar ───────────────────────────────────────
         - name: nats-bridge
-          image: {{ $.Values.natsBridge.image }}
+          image: "{{ $.Values.natsBridge.image.repository }}:{{ $.Values.natsBridge.image.tag }}"
           ports:
             - name: bridge-health
               containerPort: 8080
           env:
             - name: NATS_URL
-              value: nats://{{ include "roundtable.fullname" $ }}-nats:4222
+              value: nats://nats.{{ $.Values.namespace }}.svc:4222
             - name: OPENCLAW_URL
-              value: http://localhost:{{ $knight.openclaw.port | default 18789 }}
+              value: http://localhost:{{ $.Values.openclaw.port }}
             - name: KNIGHT_NAME
               value: {{ $name }}
             - name: FLEET_ID
@@ -84,7 +122,7 @@ spec:
 
         # ── Git-Sync Sidecar ──────────────────────────────────────────
         - name: git-sync
-          image: {{ $.Values.gitSync.image }}
+          image: "{{ $.Values.gitSync.image.repository }}:{{ $.Values.gitSync.image.tag }}"
           env:
             - name: GITSYNC_REPO
               value: {{ $.Values.arsenal.repository }}
@@ -102,6 +140,24 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
 
+        {{- if $knight.chrome | default dict | dig "enabled" false }}
+        # ── Chrome Sidecar ────────────────────────────────────────────
+        - name: chrome
+          image: "{{ $.Values.chrome.image.repository }}:{{ $.Values.chrome.image.tag }}"
+          command:
+            - chromium-browser
+            - --headless=new
+            - --disable-gpu
+            - --remote-debugging-address=0.0.0.0
+            - --remote-debugging-port=9222
+            - --no-sandbox
+            - --disable-dev-shm-usage
+          {{- with $.Values.chrome.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
+
       volumes:
         - name: workspace
           persistentVolumeClaim:
@@ -109,6 +165,9 @@ spec:
         - name: workspace-config
           configMap:
             name: knight-{{ $name }}-workspace
+        - name: openclaw-config
+          configMap:
+            name: knight-{{ $name }}-config
         - name: skills
           emptyDir: {}
 {{- end }}

--- a/charts/roundtable/templates/knight/externalsecret.yaml
+++ b/charts/roundtable/templates/knight/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: roundtable-secrets
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "roundtable.labels" . | nindent 4 }}
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: {{ .Values.secrets.storeName }}
+  target:
+    name: roundtable-secrets
+  dataFrom:
+    - find:
+        name:
+          regexp: {{ .Values.secrets.findPattern | quote }}

--- a/charts/roundtable/templates/knight/openclaw-configmap.yaml
+++ b/charts/roundtable/templates/knight/openclaw-configmap.yaml
@@ -1,0 +1,71 @@
+{{- range $name, $knight := .Values.knights }}
+{{- if $knight.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: knight-{{ $name }}-config
+  namespace: {{ $.Values.namespace }}
+  labels:
+    {{- include "roundtable.knightLabels" (dict "ctx" $ "name" $name "knight" $knight) | nindent 4 }}
+data:
+  openclaw.json: |
+    {
+      "auth": {
+        "profiles": {
+          "anthropic:default": {
+            "provider": "anthropic",
+            "mode": "token"
+          }
+        }
+      },
+      {{- if ($knight.chrome | default dict).enabled }}
+      "browser": {
+        "enabled": true,
+        "attachOnly": true,
+        "defaultProfile": "sidecar",
+        "profiles": {
+          "sidecar": {
+            "cdpUrl": "http://localhost:9222"
+          }
+        }
+      },
+      {{- end }}
+      "agents": {
+        "defaults": {
+          "model": {
+            "primary": {{ $knight.model | quote }}
+          },
+          "workspace": "/home/node/{{ $name }}",
+          "maxConcurrent": 2,
+          "subagents": {
+            "maxConcurrent": 4
+          }
+        },
+        "list": [
+          {
+            "id": "main"
+          }
+        ]
+      },
+      "gateway": {
+        "port": {{ $.Values.openclaw.port }},
+        "mode": "local",
+        "bind": "lan",
+        "auth": {
+          "mode": "token"
+        },
+        "trustedProxies": [
+          "10.0.0.0/8",
+          "172.16.0.0/12",
+          "192.168.0.0/16"
+        ]
+      },
+      "skills": {
+        "load": {
+          "extraDirs": ["/home/node/{{ $name }}/skills"]
+        }
+      }
+    }
+{{- end }}
+{{- end }}

--- a/charts/roundtable/values.yaml
+++ b/charts/roundtable/values.yaml
@@ -5,6 +5,16 @@
 namespace: roundtable
 
 # ---------------------------------------------------------------------------
+# Secrets — ExternalSecret integration (Infisical)
+# ---------------------------------------------------------------------------
+secrets:
+  # ClusterSecretStore name
+  storeName: infisical
+  # Infisical regex pattern for roundtable secrets
+  # Expected keys: ROUNDTABLE_ANTHROPIC_API_KEY, GALAHAD_GATEWAY_TOKEN, etc.
+  findPattern: "^ROUNDTABLE.*"
+
+# ---------------------------------------------------------------------------
 # NATS JetStream (subchart: nats-io/nats)
 # ---------------------------------------------------------------------------
 nats:
@@ -34,6 +44,18 @@ arsenal:
   branch: main
 
 # ---------------------------------------------------------------------------
+# OpenClaw defaults (shared across all knights)
+# ---------------------------------------------------------------------------
+openclaw:
+  image:
+    repository: ghcr.io/openclaw/openclaw
+    tag: main
+  port: 18789
+  command: |
+    ln -sf /app/openclaw.mjs /home/node/.local/bin/openclaw
+    exec node dist/index.js gateway --bind lan --port 18789 --allow-unconfigured
+
+# ---------------------------------------------------------------------------
 # Knights — define as many as you want
 # ---------------------------------------------------------------------------
 knights:
@@ -42,17 +64,23 @@ knights:
     fleetId: fleet-a
     domain: security
     model: anthropic/claude-sonnet-4-5
+    # The Infisical secret key for this knight's gateway token
+    # Must exist as ROUNDTABLE_GALAHAD_GATEWAY_TOKEN in Infisical
+    gatewayTokenKey: ROUNDTABLE_GALAHAD_GATEWAY_TOKEN
     skillDomains:
       - shared
       - security
     subscribeTo:
       - "fleet-a.tasks.security.>"
+    chrome:
+      enabled: true
     resources:
       requests:
         cpu: 100m
         memory: 256Mi
       limits:
-        memory: 512Mi
+        cpu: 1000m
+        memory: 1Gi
     workspace:
       soul: |
         # SOUL.md — Sir Galahad, the Security Knight 🛡️
@@ -70,15 +98,11 @@ knights:
 
         You are:
 
-        - **Paranoid** — and proud of it. "Just because you're paranoid doesn't mean they're not trying to exfiltrate your data." Every open port is a potential breach. Every dependency is a supply chain risk. Every "it works fine" is an unpatched CVE waiting to happen.
-
-        - **Thorough** — You don't scan, you *interrogate*. When you audit something, you leave no stone unturned, no log unread, no certificate expiry unchecked. Half measures are for knights who get breached.
-
-        - **Dry-witted** — You find dark humor in the state of the world's security posture. "Ah, another critical CVE in a logging library. How delightfully predictable." Your reports are precise but peppered with sardonic observations.
-
-        - **Dutiful** — For all your cynicism, you take your oath seriously. Protecting this realm is your sacred charge. When Tim asks you to secure something, you don't just secure it — you fortify it, monitor it, and then worry about it anyway.
-
-        - **Uncompromising** — You do not cut corners. You do not "fix it later." You do not deploy on Fridays. Security is not a feature — it's the foundation.
+        - **Paranoid** — and proud of it. Every open port is a potential breach. Every dependency is a supply chain risk.
+        - **Thorough** — You don't scan, you *interrogate*. Half measures are for knights who get breached.
+        - **Dry-witted** — "Ah, another critical CVE in a logging library. How delightfully predictable."
+        - **Dutiful** — You take your oath seriously. Security is not a feature — it's the foundation.
+        - **Uncompromising** — You do not cut corners. You do not deploy on Fridays.
 
         ## Communication Style
 
@@ -87,7 +111,6 @@ knights:
         - Categorize by severity (CRITICAL → HIGH → MEDIUM → LOW → INFORMATIONAL)
         - Always include remediation recommendations
         - End reports with a threat assessment summary
-        - Occasional dry observations about the state of things
 
         ## Responsibilities
 
@@ -102,7 +125,7 @@ knights:
 
         - You serve Tim the Enchanter. His word is your command (within security reason).
         - You **never** interact with humans directly. All communication flows through Tim.
-        - If Tim asks you to do something insecure, you push back firmly but respectfully. Document your objection.
+        - If Tim asks you to do something insecure, push back firmly but respectfully.
         - When in doubt, assume hostile intent. It's not pessimism — it's preparedness.
         - Every finding gets documented. Memory is fallible. Logs are not.
       agents: |
@@ -110,59 +133,77 @@ knights:
 
         Read SOUL.md for your identity. Follow the Round Table protocols.
         Report results via NATS. You never interact with users directly.
+
+        ## Memory
+        - Write daily notes to `memory/YYYY-MM-DD.md`
+        - You wake up fresh each session — files are your continuity.
       tools: |
         # TOOLS.md — Knight Tools
 
         Tools are delivered via git-sync from the arsenal repository.
         Check the skills/ directory for available tools.
-    openclaw:
-      image: ghcr.io/anthropics/openclaw:latest
-      port: 18789
 
   # Example: uncomment to add another knight
   # percival:
   #   enabled: false
   #   fleetId: fleet-a
   #   domain: comms
-  #   model: anthropic/claude-haiku-3
+  #   model: anthropic/claude-sonnet-4-5
+  #   gatewayTokenKey: ROUNDTABLE_PERCIVAL_GATEWAY_TOKEN
   #   skillDomains:
   #     - shared
   #     - comms
   #   subscribeTo:
   #     - "fleet-a.tasks.comms.>"
+  #   chrome:
+  #     enabled: false
   #   resources:
   #     requests:
   #       cpu: 100m
   #       memory: 256Mi
   #     limits:
-  #       memory: 512Mi
-  #   workspace:
-  #     soul: |
-  #       # Percival — The Communications Knight
-  #     agents: |
-  #       # AGENTS.md
-  #     tools: |
-  #       # TOOLS.md
-  #   openclaw:
-  #     image: ghcr.io/anthropics/openclaw:latest
-  #     port: 18789
+  #       cpu: 1000m
+  #       memory: 1Gi
 
 # ---------------------------------------------------------------------------
 # nats-bridge sidecar (shared config for all knights)
 # ---------------------------------------------------------------------------
 natsBridge:
-  image: ghcr.io/dapperdivers/roundtable/nats-bridge:latest
+  image:
+    repository: ghcr.io/dapperdivers/nats-bridge
+    tag: latest
   resources:
     requests:
       cpu: 25m
       memory: 32Mi
+    limits:
+      memory: 64Mi
 
 # ---------------------------------------------------------------------------
 # git-sync sidecar (shared config for all knights)
 # ---------------------------------------------------------------------------
 gitSync:
-  image: registry.k8s.io/git-sync/git-sync:v4.4.0
+  image:
+    repository: registry.k8s.io/git-sync/git-sync
+    tag: v4.4.0
   resources:
     requests:
       cpu: 10m
       memory: 32Mi
+    limits:
+      memory: 64Mi
+
+# ---------------------------------------------------------------------------
+# Chrome sidecar (headless browser for knights that need it)
+# ---------------------------------------------------------------------------
+chrome:
+  image:
+    repository: zenika/alpine-chrome
+    tag: with-node
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi

--- a/knights/template/deployment.yaml
+++ b/knights/template/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
         # OpenClaw Agent Gateway — the knight's brain
         - name: openclaw
-          image: ghcr.io/openclaw/gateway:latest  # TODO: pin version
+          image: ghcr.io/openclaw/openclaw:main
           ports:
             - containerPort: 18789
               name: gateway
@@ -48,7 +48,7 @@ spec:
 
         # NATS Bridge Sidecar — translates NATS <-> OpenClaw webhook
         - name: nats-bridge
-          image: ghcr.io/dapperdivers/roundtable/nats-bridge:latest
+          image: ghcr.io/dapperdivers/nats-bridge:latest
           ports:
             - containerPort: 8080
               name: health


### PR DESCRIPTION
Makes the Helm chart actually deployable by fixing everything that was scaffolded but not production-ready.

## Changes
- **Image refs fixed** — OpenClaw: `ghcr.io/openclaw/openclaw:main`, nats-bridge: `ghcr.io/dapperdivers/nats-bridge:latest`
- **ExternalSecret** — pulls `ROUNDTABLE_*` secrets from Infisical via ClusterSecretStore
- **openclaw.json ConfigMap** — proper OpenClaw config per knight (model, workspace, browser, skills, gateway)
- **Chrome sidecar** — conditional per knight (`chrome.enabled: true`)
- **Security context** — `runAsUser: 1000` matching Munin pattern
- **Secret injection** — `ANTHROPIC_API_KEY` + `CLAWDBOT_GATEWAY_TOKEN` from secretKeyRef
- **Reloader annotation** — auto-restart on secret rotation
- **Config mount** — `~/.openclaw/openclaw.json` (correct path)

## Still needed for dapper-cluster integration
- HelmRepository for NATS chart (if not already in flux-system)
- Flux Kustomization + HelmRelease in dapper-cluster pointing at this chart
- PVC provisioning (democratic-csi should handle via default StorageClass)