### PR TITLE
ci: optimize Docker build with layer caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
           controller-gen object paths="./api/..."
           controller-gen crd rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
+      - uses: docker/setup-buildx-action@v3
+
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -72,7 +74,8 @@ jobs:
         with:
           context: .
           push: true
-          no-cache: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: |
             ghcr.io/dapperdivers/roundtable:latest
             ghcr.io/dapperdivers/roundtable:${{ github.sha }}


### PR DESCRIPTION
## Problem

Docker builds taking 2m30s+ due to `no-cache: true` forcing full rebuilds on every commit.

## Changes

- ✅ Added `docker/setup-buildx-action@v3` for BuildKit features
- ✅ Enabled GitHub Actions cache (`cache-from/cache-to`)
- ❌ Removed `no-cache: true` (was the bottleneck)

## Expected Impact

| Scenario | Before | After |
|----------|--------|-------|
| First build | 2m30s | 2m30s (building cache) |
| Cached builds | 2m30s | 30-45s (60% faster) |
| No-op builds | 2m30s | 15-20s |

**Total CI time: 5min → 2-3min on cached runs**

## Cache Behavior

GitHub Actions cache persists Docker layers between runs:
- Cache hit: Only changed layers rebuild
- Cache miss: Full rebuild, then cache stored
- Cache scoped to branch (main gets own cache)

Safe to merge — worst case is same speed as now (if cache fails), best case is 60% faster.