### PR TITLE
fix(docker): include pkg/ in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 !api/
 !cmd/
 !internal/
+!pkg/
 !go.mod
 !go.sum
 


### PR DESCRIPTION
The `.dockerignore` allowlist was missing `pkg/`, causing Docker builds to fail after the NATS library extraction (PR #30).