### PR TITLE
fix: ensure ServiceAccount exists during assembling phase

### DIFF
--- a/internal/controller/mission_controller.go
+++ b/internal/controller/mission_controller.go
@@ -363,6 +363,24 @@ func (r *MissionReconciler) reconcileProvisioning(ctx context.Context, mission *
 func (r *MissionReconciler) reconcileAssembling(ctx context.Context, mission *aiv1alpha1.Mission) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
+	// Ensure mission ServiceAccount exists for ephemeral knights.
+	// When roundTableRef is set, provisioning is skipped, but ephemeral knights
+	// still need a mission-scoped SA for their pods.
+	hasEphemeral := false
+	for _, mk := range mission.Spec.Knights {
+		if mk.Ephemeral {
+			hasEphemeral = true
+			break
+		}
+	}
+	if hasEphemeral {
+		serviceAccountName := fmt.Sprintf("mission-%s", mission.Name)
+		if err := r.ensureMissionServiceAccount(ctx, mission, serviceAccountName); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to ensure ServiceAccount: %w", err)
+		}
+		log.Info("Ensured mission ServiceAccount", "name", serviceAccountName)
+	}
+
 	// Resolve the RoundTable lazily — only fetched when an ephemeral knight needs it.
 	var rt *aiv1alpha1.RoundTable
 	getRoundTable := func() (*aiv1alpha1.RoundTable, error) {


### PR DESCRIPTION
## Problem

When a mission uses `roundTableRef` (existing RoundTable), the provisioning phase is skipped entirely. However, ephemeral knights still reference a mission-scoped ServiceAccount (`mission-<name>`).

Without this fix, the SA is never created, causing pod creation to fail:
```
Error creating: pods "phase3b-test-scout-1-..." is forbidden: error looking up service account roundtable/mission-phase3b-test: serviceaccount "mission-phase3b-test" not found
```

The mission then times out in Assembling with `Assembly timeout: knights not ready`.

## Fix

Check for ephemeral knights at the start of `reconcileAssembling` and ensure the mission-scoped ServiceAccount exists before creating Knight CRs. This is idempotent — `ensureMissionServiceAccount` is already a create-if-not-exists pattern.

## Root Cause

`ensureMissionServiceAccount` was only called in `reconcileProvisioning` (line 297), which is skipped when `spec.roundTableRef` is set (line 265-270). But `buildEphemeralKnight` always stamps `ServiceAccountName = mission-<name>` on the knight spec (line 1431).

## Testing

- [x] Manual: Reproduced with `phase3b-test` mission using `roundTableRef: personal`
- [ ] CI: Go build + existing tests