### PR TITLE
fix: make hardcoded fleet-a NATS prefix configurable via env vars

### DIFF
--- a/internal/controller/chain_controller.go
+++ b/internal/controller/chain_controller.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"text/template"
@@ -50,13 +51,28 @@ type natsConfig struct {
 	ResultsStream string // e.g. "fleet_a_results" or "chelonian_results"
 }
 
-// defaultNATSConfig is the fallback when no RoundTable is specified.
+// defaultNATSConfig returns the fallback config when no RoundTable is specified.
 // This is only used for legacy chains without a roundTableRef or missionRef.
 // New chains should always resolve config from their parent RoundTable CR.
-var defaultNATSConfig = natsConfig{
-	SubjectPrefix: "fleet-a",
-	TasksStream:   "fleet_a_tasks",
-	ResultsStream: "fleet_a_results",
+// Values are read from environment variables to avoid hardcoding a specific table prefix.
+func defaultNATSConfig() natsConfig {
+	prefix := os.Getenv("NATS_DEFAULT_PREFIX")
+	if prefix == "" {
+		prefix = "fleet-a"
+	}
+	tasksStream := os.Getenv("NATS_DEFAULT_TASKS_STREAM")
+	if tasksStream == "" {
+		tasksStream = strings.ReplaceAll(prefix, "-", "_") + "_tasks"
+	}
+	resultsStream := os.Getenv("NATS_DEFAULT_RESULTS_STREAM")
+	if resultsStream == "" {
+		resultsStream = strings.ReplaceAll(prefix, "-", "_") + "_results"
+	}
+	return natsConfig{
+		SubjectPrefix: prefix,
+		TasksStream:   tasksStream,
+		ResultsStream: resultsStream,
+	}
 }
 
 // ChainReconciler reconciles a Chain object.
@@ -733,7 +749,7 @@ func (r *ChainReconciler) ensureNATS(ctx context.Context) error {
 // Falls back to defaultNATSConfig if no roundTableRef is specified.
 func (r *ChainReconciler) resolveNATSConfig(ctx context.Context, chain *aiv1alpha1.Chain) (natsConfig, error) {
 	if chain.Spec.RoundTableRef == "" {
-		return defaultNATSConfig, nil
+		return defaultNATSConfig(), nil
 	}
 
 	rt := &aiv1alpha1.RoundTable{}

--- a/internal/controller/knight_controller.go
+++ b/internal/controller/knight_controller.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -1007,7 +1008,12 @@ func deriveResultsPrefix(subjects []string) string {
 			return parts[0] + ".results"
 		}
 	}
-	return "fleet-a.results" // ultimate fallback for legacy knights without subjects
+	// Fallback: use env-configurable prefix for legacy knights without subjects
+	prefix := os.Getenv("NATS_DEFAULT_PREFIX")
+	if prefix == "" {
+		prefix = "fleet-a"
+	}
+	return prefix + ".results"
 }
 
 func capitalizeFirst(s string) string {

--- a/internal/controller/plan.go
+++ b/internal/controller/plan.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -578,7 +579,10 @@ func (r *MissionReconciler) pollPlanningResult(ctx context.Context, mission *aiv
 	// Derive the results stream and subject prefix from the planner knight's NATS config.
 	// The planner publishes to its own table's results stream, not the mission's.
 	resultsStream := plannerKnight.Spec.NATS.ResultsStream
-	subjectPrefix := "fleet-a" // fallback
+	subjectPrefix := os.Getenv("NATS_DEFAULT_PREFIX")
+	if subjectPrefix == "" {
+		subjectPrefix = "fleet-a" // legacy fallback
+	}
 	if len(plannerKnight.Spec.NATS.Subjects) > 0 {
 		// Extract prefix from first subject: "fleet-a.tasks.domain.>" → "fleet-a"
 		parts := strings.SplitN(plannerKnight.Spec.NATS.Subjects[0], ".tasks.", 2)


### PR DESCRIPTION
The operator had 3 hardcoded fleet-a fallbacks. Now reads NATS_DEFAULT_PREFIX env var. Backward compatible.