### PR TITLE
feat: browser capability — headless Chrome sidecar for knights

### DIFF
--- a/api/v1alpha1/knight_types.go
+++ b/api/v1alpha1/knight_types.go
@@ -81,6 +81,10 @@ type KnightSpec struct {
 	// +optional
 	Prompt *KnightPrompt `json:"prompt,omitempty"`
 
+	// capabilities configures optional runtime capabilities for the knight pod.
+	// +optional
+	Capabilities *KnightCapabilities `json:"capabilities,omitempty"`
+
 	// resources defines compute resource requirements for the knight container.
 	// +optional
 	Resources *KnightResources `json:"resources,omitempty"`
@@ -165,6 +169,14 @@ type KnightWorkspace struct {
 	// +kubebuilder:default="1Gi"
 	// +optional
 	Size string `json:"size,omitempty"`
+}
+
+// KnightCapabilities defines optional runtime capabilities for the knight pod.
+type KnightCapabilities struct {
+	// browser enables a headless Chrome sidecar with agent-browser CLI for web automation.
+	// When true, the operator injects a browser sidecar and sets BROWSER_ENABLED=true.
+	// +optional
+	Browser bool `json:"browser,omitempty"`
 }
 
 // KnightTools defines system-level tools the knight needs installed.

--- a/internal/controller/knight_controller.go
+++ b/internal/controller/knight_controller.go
@@ -518,6 +518,11 @@ func (r *KnightReconciler) buildPodSpec(ctx context.Context, k *aiv1alpha1.Knigh
 		WithSkillFilter().
 		WithGitSync()
 
+	// Optional capabilities
+	if knight.Spec.Capabilities != nil && knight.Spec.Capabilities.Browser {
+		builder.WithBrowser()
+	}
+
 	return builder.Build(ctx)
 }
 

--- a/internal/knight/pod_builder.go
+++ b/internal/knight/pod_builder.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	aiv1alpha1 "github.com/dapperdivers/roundtable/api/v1alpha1"
@@ -365,6 +366,43 @@ func (b *PodBuilder) WithGitSync() *PodBuilder {
 	return b
 }
 
+// WithBrowser adds a headless Chrome sidecar with agent-browser for web automation.
+func (b *PodBuilder) WithBrowser() *PodBuilder {
+	browserContainer := corev1.Container{
+		Name:  "browser",
+		Image: "ghcr.io/dapperdivers/knight-browser:latest",
+		Ports: []corev1.ContainerPort{
+			{ContainerPort: 9222, Name: "cdp", Protocol: corev1.ProtocolTCP},
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+		},
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				TCPSocket: &corev1.TCPSocketAction{
+					Port: intstr.FromInt32(9222),
+				},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       10,
+		},
+		SecurityContext: &corev1.SecurityContext{
+			RunAsNonRoot:             util.BoolPtr(true),
+			ReadOnlyRootFilesystem:   util.BoolPtr(false),
+			AllowPrivilegeEscalation: util.BoolPtr(false),
+		},
+	}
+
+	b.sidecars = append(b.sidecars, browserContainer)
+	return b
+}
+
 // Build assembles the complete PodSpec with all configured components.
 func (b *PodBuilder) Build(ctx context.Context) corev1.PodSpec {
 	// Determine image
@@ -391,6 +429,12 @@ func (b *PodBuilder) Build(ctx context.Context) corev1.PodSpec {
 		{Name: "METRICS_PORT", Value: "3000"},
 		{Name: "LOG_LEVEL", Value: "info"},
 		{Name: "TZ", Value: "America/Chicago"},
+	}
+
+	// Browser capability
+	if b.knight.Spec.Capabilities != nil && b.knight.Spec.Capabilities.Browser {
+		env = append(env, corev1.EnvVar{Name: "BROWSER_ENABLED", Value: "true"})
+		env = append(env, corev1.EnvVar{Name: "BROWSER_CDP_URL", Value: "http://localhost:9222"})
 	}
 
 	// Append user-defined env vars


### PR DESCRIPTION
## 🖥️ Browser Capability for Knights

Adds opt-in headless Chrome browser support via sidecar injection.

### Changes
- **Knight CRD**: New `spec.capabilities.browser` field
- **PodBuilder**: `WithBrowser()` injects Chrome sidecar on port 9222
- **Controller**: Wires capability check in reconciliation
- **Env vars**: `BROWSER_ENABLED=true` + `BROWSER_CDP_URL` injected

### Usage
```yaml
apiVersion: ai.roundtable.io/v1alpha1
kind: Knight
metadata:
  name: agravain
spec:
  capabilities:
    browser: true
  # ... rest of spec
```

### Architecture
```
Knight Pod
├── app (pi-knight) — gets BROWSER_ENABLED=true
├── browser (Chrome sidecar) — CDP on :9222
├── skill-filter
└── git-sync
```

### Sidecar: ghcr.io/dapperdivers/knight-browser
- Headless Chrome + agent-browser CLI
- 50m CPU / 128-512Mi memory
- TCP readiness probe on CDP port
- Non-root, no privilege escalation

Part of browser upgrade: operator + pi-knight runtime + arsenal skill