### PR TITLE
feat: introduce pluggable RuntimeBackend interface

### DIFF
--- a/api/v1alpha1/knight_types.go
+++ b/api/v1alpha1/knight_types.go
@@ -129,6 +129,10 @@ type KnightSpec struct {
 	// +optional
 	Workspace *KnightWorkspace `json:"workspace,omitempty"`
 
+	// lifecycle controls suspend/resume behavior.
+	// +optional
+	Lifecycle *KnightLifecycle `json:"lifecycle,omitempty"`
+
 	// suspended, if true, scales the knight deployment to 0 replicas.
 	// +kubebuilder:default=false
 	// +optional
@@ -169,6 +173,21 @@ type KnightWorkspace struct {
 	// +kubebuilder:default="1Gi"
 	// +optional
 	Size string `json:"size,omitempty"`
+}
+
+// KnightLifecycle controls suspend/resume behavior for the knight.
+type KnightLifecycle struct {
+	// suspendPolicy controls when the knight is suspended.
+	// Values: auto, manual, never (default: never)
+	// +kubebuilder:validation:Enum=auto;manual;never
+	// +kubebuilder:default="never"
+	// +optional
+	SuspendPolicy string `json:"suspendPolicy,omitempty"`
+
+	// idleTimeout is how long after the last task before auto-suspending.
+	// Only used when SuspendPolicy is "auto" (e.g., "30m", "1h").
+	// +optional
+	IdleTimeout string `json:"idleTimeout,omitempty"`
 }
 
 // KnightCapabilities defines optional runtime capabilities for the knight pod.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/dapperdivers/roundtable/internal/controller"
 	"github.com/dapperdivers/roundtable/internal/mission"
 	natspkg "github.com/dapperdivers/roundtable/pkg/nats"
+	rtruntime "github.com/dapperdivers/roundtable/pkg/runtime"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -196,11 +197,20 @@ func main() {
 		}
 	}()
 
-	if err := (&controller.KnightReconciler{
+	defaultImage := os.Getenv("DEFAULT_KNIGHT_IMAGE")
+	knightReconciler := &controller.KnightReconciler{
 		Client:       mgr.GetClient(),
 		Scheme:       mgr.GetScheme(),
-		DefaultImage: os.Getenv("DEFAULT_KNIGHT_IMAGE"),
-	}).SetupWithManager(mgr); err != nil {
+		DefaultImage: defaultImage,
+	}
+	// Wire up the RuntimeBackend with a PodSpecBuilder that delegates to the reconciler's buildDeploymentSpec
+	knightReconciler.RuntimeBackend = rtruntime.NewDeploymentBackend(
+		mgr.GetClient(),
+		mgr.GetScheme(),
+		defaultImage,
+		knightReconciler.BuildDeploymentSpec,
+	)
+	if err := knightReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "Knight")
 		os.Exit(1)
 	}

--- a/internal/controller/knight_controller.go
+++ b/internal/controller/knight_controller.go
@@ -18,10 +18,7 @@ package controller
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -40,6 +37,7 @@ import (
 
 	aiv1alpha1 "github.com/dapperdivers/roundtable/api/v1alpha1"
 	knightpkg "github.com/dapperdivers/roundtable/internal/knight"
+	rtruntime "github.com/dapperdivers/roundtable/pkg/runtime"
 )
 
 const (
@@ -49,21 +47,17 @@ const (
 	specHashAnnotation     = "roundtable.io/spec-hash"
 )
 
-// nixToolsHash computes a deterministic hash of the Nix tool list.
-// Used to detect when tools change so stale Nix PVCs can be recycled.
-func nixToolsHash(tools []string) string {
-	sorted := make([]string, len(tools))
-	copy(sorted, tools)
-	sort.Strings(sorted)
-	h := sha256.Sum256([]byte(strings.Join(sorted, ",")))
-	return hex.EncodeToString(h[:8]) // 16-char hex prefix
-}
-
 // KnightReconciler reconciles a Knight object
 type KnightReconciler struct {
 	client.Client
 	Scheme       *runtime.Scheme
 	DefaultImage string // Default pi-knight image (set via DEFAULT_KNIGHT_IMAGE env var)
+
+	// RuntimeBackend abstracts the lifecycle of Knight runtime resources.
+	// When set, the controller delegates Deployment reconciliation and
+	// suspend/resume to this backend. When nil, falls back to the
+	// inline reconcileDeployment / reconcileSuspended methods.
+	RuntimeBackend rtruntime.RuntimeBackend
 }
 
 // +kubebuilder:rbac:groups=ai.roundtable.io,resources=knights,verbs=get;list;watch;create;update;patch;delete
@@ -118,6 +112,12 @@ func (r *KnightReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	// Handle suspended state
 	if knight.Spec.Suspended {
+		if r.RuntimeBackend != nil {
+			if err := r.RuntimeBackend.Suspend(ctx, knight); err != nil {
+				return ctrl.Result{}, err
+			}
+			return r.finishSuspended(ctx, knight)
+		}
 		return r.reconcileSuspended(ctx, knight)
 	}
 
@@ -137,9 +137,16 @@ func (r *KnightReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	// 3. Deployment (pi-knight + skill-filter sidecar)
-	if err := r.reconcileDeployment(ctx, knight); err != nil {
-		reconcileErr = err
-		log.Error(err, "Failed to reconcile Deployment")
+	if r.RuntimeBackend != nil {
+		if err := r.RuntimeBackend.Reconcile(ctx, knight); err != nil {
+			reconcileErr = err
+			log.Error(err, "Failed to reconcile Deployment via RuntimeBackend")
+		}
+	} else {
+		if err := r.reconcileDeployment(ctx, knight); err != nil {
+			reconcileErr = err
+			log.Error(err, "Failed to reconcile Deployment")
+		}
 	}
 
 	// Update status based on reconciliation results
@@ -186,6 +193,24 @@ func (r *KnightReconciler) reconcileSuspended(ctx context.Context, knight *aiv1a
 		return ctrl.Result{}, err
 	}
 
+	return ctrl.Result{}, nil
+}
+
+// finishSuspended updates the Knight status after the RuntimeBackend has suspended it.
+func (r *KnightReconciler) finishSuspended(ctx context.Context, knight *aiv1alpha1.Knight) (ctrl.Result, error) {
+	knight.Status.Phase = aiv1alpha1.KnightPhaseSuspended
+	knight.Status.Ready = false
+	meta.SetStatusCondition(&knight.Status.Conditions, metav1.Condition{
+		Type:               "Available",
+		Status:             metav1.ConditionFalse,
+		Reason:             "Suspended",
+		Message:            "Knight is suspended",
+		ObservedGeneration: knight.Generation,
+	})
+	knight.Status.ObservedGeneration = knight.Generation
+	if err := r.Status().Update(ctx, knight); err != nil {
+		return ctrl.Result{}, err
+	}
 	return ctrl.Result{}, nil
 }
 
@@ -298,7 +323,7 @@ func (r *KnightReconciler) reconcilePVC(ctx context.Context, knight *aiv1alpha1.
 	// Create Nix PVC if tools.nix is configured, recycle if tools changed
 	if knight.Spec.Tools != nil && len(knight.Spec.Tools.Nix) > 0 {
 		nixPVCName := fmt.Sprintf("knight-%s-nix", knight.Name)
-		currentHash := nixToolsHash(knight.Spec.Tools.Nix)
+		currentHash := knightpkg.NixToolsHash(knight.Spec.Tools.Nix)
 		nixPVC := &corev1.PersistentVolumeClaim{}
 		err := r.Get(ctx, types.NamespacedName{Name: nixPVCName, Namespace: knight.Namespace}, nixPVC)
 
@@ -437,7 +462,7 @@ func (r *KnightReconciler) reconcileDeployment(ctx context.Context, knight *aiv1
 		"roundtable.io/domain": knight.Spec.Domain,
 	}
 	if knight.Spec.Tools != nil && len(knight.Spec.Tools.Nix) > 0 {
-		podAnnotations[nixToolsHashAnnotation] = nixToolsHash(knight.Spec.Tools.Nix)
+		podAnnotations[nixToolsHashAnnotation] = knightpkg.NixToolsHash(knight.Spec.Tools.Nix)
 	}
 	desired.Spec.Template.ObjectMeta.Annotations = podAnnotations
 	desired.Spec.Template.Spec = r.buildPodSpec(ctx, knight)
@@ -500,8 +525,32 @@ func (r *KnightReconciler) reconcileDeployment(ctx context.Context, knight *aiv1
 	return nil
 }
 
-// buildPodSpec constructs the complete pod spec for a knight.
-// Matches the proven deployment pattern from the working Helm-based knights.
+// BuildDeploymentSpec constructs the full DeploymentSpec for a Knight.
+// Exported so it can be passed as a PodSpecBuilder to RuntimeBackend.
+func (r *KnightReconciler) BuildDeploymentSpec(ctx context.Context, knight *aiv1alpha1.Knight) appsv1.DeploymentSpec {
+	labels := map[string]string{
+		"app.kubernetes.io/name":       "knight",
+		"app.kubernetes.io/instance":   knight.Name,
+		"app.kubernetes.io/managed-by": "roundtable-operator",
+		"roundtable.io/domain":         knight.Spec.Domain,
+	}
+	replicas := int32(1)
+	return appsv1.DeploymentSpec{
+		Replicas: &replicas,
+		Strategy: appsv1.DeploymentStrategy{
+			Type: appsv1.RecreateDeploymentStrategyType,
+		},
+		Selector: &metav1.LabelSelector{
+			MatchLabels: labels,
+		},
+		Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: labels,
+			},
+			Spec: r.buildPodSpec(ctx, knight),
+		},
+	}
+}
 
 // buildPodSpec constructs the complete pod spec for a knight using the composable builder.
 func (r *KnightReconciler) buildPodSpec(ctx context.Context, k *aiv1alpha1.Knight) corev1.PodSpec {
@@ -527,9 +576,19 @@ func (r *KnightReconciler) buildPodSpec(ctx context.Context, k *aiv1alpha1.Knigh
 }
 
 func (r *KnightReconciler) updateStatus(ctx context.Context, knight *aiv1alpha1.Knight, reconcileErr error) error {
-	// Check deployment readiness
-	deploy := &appsv1.Deployment{}
-	deployErr := r.Get(ctx, types.NamespacedName{Name: knight.Name, Namespace: knight.Namespace}, deploy)
+	// Check deployment readiness — prefer RuntimeBackend if available
+	var isReady bool
+	if r.RuntimeBackend != nil {
+		ready, err := r.RuntimeBackend.IsReady(ctx, knight)
+		if err == nil {
+			isReady = ready
+		}
+	} else {
+		deploy := &appsv1.Deployment{}
+		if err := r.Get(ctx, types.NamespacedName{Name: knight.Name, Namespace: knight.Namespace}, deploy); err == nil {
+			isReady = deploy.Status.ReadyReplicas > 0
+		}
+	}
 
 	if reconcileErr != nil {
 		knight.Status.Phase = aiv1alpha1.KnightPhaseDegraded
@@ -541,7 +600,7 @@ func (r *KnightReconciler) updateStatus(ctx context.Context, knight *aiv1alpha1.
 			Message:            reconcileErr.Error(),
 			ObservedGeneration: knight.Generation,
 		})
-	} else if deployErr == nil && deploy.Status.ReadyReplicas > 0 {
+	} else if isReady {
 		knight.Status.Phase = aiv1alpha1.KnightPhaseReady
 		knight.Status.Ready = true
 		meta.SetStatusCondition(&knight.Status.Conditions, metav1.Condition{

--- a/internal/knight/helpers.go
+++ b/internal/knight/helpers.go
@@ -18,13 +18,25 @@ package knight
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	aiv1alpha1 "github.com/dapperdivers/roundtable/api/v1alpha1"
 )
+
+// NixToolsHash computes a deterministic hash of the Nix tool list.
+// Used to detect when tools change so stale Nix PVCs can be recycled.
+func NixToolsHash(tools []string) string {
+	sorted := make([]string, len(tools))
+	copy(sorted, tools)
+	sort.Strings(sorted)
+	h := sha256.Sum256([]byte(strings.Join(sorted, ",")))
+	return hex.EncodeToString(h[:8]) // 16-char hex prefix
+}
 
 // GenerateFlakeNix produces the flake.nix content for Nix package provisioning.
 func GenerateFlakeNix(knight *aiv1alpha1.Knight) string {

--- a/pkg/runtime/backend.go
+++ b/pkg/runtime/backend.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2026 dapperdivers.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+
+	aiv1alpha1 "github.com/dapperdivers/roundtable/api/v1alpha1"
+)
+
+// RuntimeBackend abstracts how Knight pods are created and managed.
+// Implementations include DeploymentBackend (always-on) and SandboxBackend (scale-to-zero).
+type RuntimeBackend interface {
+	// Reconcile ensures runtime resources exist and match the Knight spec.
+	Reconcile(ctx context.Context, knight *aiv1alpha1.Knight) error
+
+	// Cleanup removes runtime resources when a Knight is deleted.
+	Cleanup(ctx context.Context, knight *aiv1alpha1.Knight) error
+
+	// IsReady returns whether the knight's runtime is ready to accept tasks.
+	IsReady(ctx context.Context, knight *aiv1alpha1.Knight) (bool, error)
+
+	// Suspend pauses the knight's runtime (e.g., scale to zero).
+	Suspend(ctx context.Context, knight *aiv1alpha1.Knight) error
+
+	// Resume wakes the knight's runtime.
+	Resume(ctx context.Context, knight *aiv1alpha1.Knight) error
+}

--- a/pkg/runtime/deployment_backend.go
+++ b/pkg/runtime/deployment_backend.go
@@ -1,0 +1,242 @@
+/*
+Copyright 2026 dapperdivers.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	aiv1alpha1 "github.com/dapperdivers/roundtable/api/v1alpha1"
+	knightpkg "github.com/dapperdivers/roundtable/internal/knight"
+)
+
+const (
+	specHashAnnotation     = "roundtable.io/spec-hash"
+	nixToolsHashAnnotation = "roundtable.io/nix-tools-hash"
+)
+
+// PodSpecBuilder is a function that constructs a PodSpec for a Knight.
+// This allows the controller to inject its own pod-building logic
+// (using PodBuilder) without the runtime package depending on internal packages.
+type PodSpecBuilder func(ctx context.Context, knight *aiv1alpha1.Knight) appsv1.DeploymentSpec
+
+// DeploymentBackend implements RuntimeBackend using Kubernetes Deployments.
+// This is the default "always-on" backend where each Knight runs as a Deployment.
+type DeploymentBackend struct {
+	Client       client.Client
+	Scheme       *runtime.Scheme
+	DefaultImage string
+
+	// BuildDeploymentSpec is a pluggable function that constructs the full
+	// DeploymentSpec for a Knight. The controller injects this to keep
+	// PodBuilder usage in the controller layer.
+	BuildDeploymentSpec PodSpecBuilder
+}
+
+// NewDeploymentBackend creates a new DeploymentBackend.
+func NewDeploymentBackend(c client.Client, scheme *runtime.Scheme, defaultImage string, builder PodSpecBuilder) *DeploymentBackend {
+	return &DeploymentBackend{
+		Client:              c,
+		Scheme:              scheme,
+		DefaultImage:        defaultImage,
+		BuildDeploymentSpec: builder,
+	}
+}
+
+// Reconcile creates or updates the Deployment for the Knight.
+func (b *DeploymentBackend) Reconcile(ctx context.Context, knight *aiv1alpha1.Knight) error {
+	log := logf.FromContext(ctx)
+
+	// Build the desired deployment spec using the injected builder
+	desiredSpec := b.BuildDeploymentSpec(ctx, knight)
+
+	labels := map[string]string{
+		"app.kubernetes.io/name":       "knight",
+		"app.kubernetes.io/instance":   knight.Name,
+		"app.kubernetes.io/managed-by": "roundtable-operator",
+		"roundtable.io/domain":         knight.Spec.Domain,
+	}
+
+	// Build a temporary deployment to compute the spec hash
+	desired := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      knight.Name,
+			Namespace: knight.Namespace,
+		},
+	}
+	desired.Spec = desiredSpec
+
+	podAnnotations := map[string]string{
+		"roundtable.io/model":  knight.Spec.Model,
+		"roundtable.io/skills": strings.Join(knight.Spec.Skills, ","),
+		"roundtable.io/domain": knight.Spec.Domain,
+	}
+	if knight.Spec.Tools != nil && len(knight.Spec.Tools.Nix) > 0 {
+		podAnnotations[nixToolsHashAnnotation] = knightpkg.NixToolsHash(knight.Spec.Tools.Nix)
+	}
+	desired.Spec.Template.ObjectMeta.Annotations = podAnnotations
+
+	desiredHash := knightpkg.DeploymentSpecHash(desired)
+
+	// Fetch or create the deployment
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      knight.Name,
+			Namespace: knight.Namespace,
+		},
+	}
+
+	replicas := int32(1)
+
+	op, err := controllerutil.CreateOrUpdate(ctx, b.Client, deploy, func() error {
+		if err := controllerutil.SetControllerReference(knight, deploy, b.Scheme); err != nil {
+			return err
+		}
+
+		// Check if the spec hash matches — if so, skip mutation
+		existingHash := ""
+		if deploy.Spec.Template.Annotations != nil {
+			existingHash = deploy.Spec.Template.Annotations[specHashAnnotation]
+		}
+		if existingHash == desiredHash {
+			return nil
+		}
+
+		// Apply desired state
+		deploy.Labels = labels
+		deploy.Spec.Replicas = &replicas
+		deploy.Spec.Strategy = appsv1.DeploymentStrategy{
+			Type: appsv1.RecreateDeploymentStrategyType,
+		}
+		deploy.Spec.Selector = &metav1.LabelSelector{
+			MatchLabels: labels,
+		}
+		deploy.Spec.Template.ObjectMeta.Labels = labels
+
+		podAnnotations[specHashAnnotation] = desiredHash
+		deploy.Spec.Template.ObjectMeta.Annotations = podAnnotations
+
+		deploy.Spec.Template.Spec = desiredSpec.Template.Spec
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("deployment reconcile failed: %w", err)
+	}
+
+	log.Info("Deployment reconciled", "operation", op,
+		"specImage", knight.Spec.Image,
+		"defaultImage", b.DefaultImage,
+		"resolvedImage", deploy.Spec.Template.Spec.Containers[0].Image)
+	return nil
+}
+
+// Cleanup deletes the Deployment owned by the Knight.
+// ConfigMaps and PVCs are handled by owner references (garbage collection).
+func (b *DeploymentBackend) Cleanup(ctx context.Context, knight *aiv1alpha1.Knight) error {
+	log := logf.FromContext(ctx)
+
+	deploy := &appsv1.Deployment{}
+	err := b.Client.Get(ctx, types.NamespacedName{Name: knight.Name, Namespace: knight.Namespace}, deploy)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get deployment for cleanup: %w", err)
+	}
+
+	if err := b.Client.Delete(ctx, deploy); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete deployment: %w", err)
+	}
+
+	log.Info("Deployment cleaned up", "knight", knight.Name)
+	return nil
+}
+
+// IsReady checks if the Knight's Deployment has at least one ready replica.
+func (b *DeploymentBackend) IsReady(ctx context.Context, knight *aiv1alpha1.Knight) (bool, error) {
+	deploy := &appsv1.Deployment{}
+	err := b.Client.Get(ctx, types.NamespacedName{Name: knight.Name, Namespace: knight.Namespace}, deploy)
+	if apierrors.IsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("failed to get deployment: %w", err)
+	}
+	return deploy.Status.ReadyReplicas >= 1, nil
+}
+
+// Suspend scales the Knight's Deployment to 0 replicas.
+func (b *DeploymentBackend) Suspend(ctx context.Context, knight *aiv1alpha1.Knight) error {
+	log := logf.FromContext(ctx)
+
+	deploy := &appsv1.Deployment{}
+	err := b.Client.Get(ctx, types.NamespacedName{Name: knight.Name, Namespace: knight.Namespace}, deploy)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get deployment for suspend: %w", err)
+	}
+
+	zero := int32(0)
+	if deploy.Spec.Replicas == nil || *deploy.Spec.Replicas != zero {
+		deploy.Spec.Replicas = &zero
+		if err := b.Client.Update(ctx, deploy); err != nil {
+			return fmt.Errorf("failed to scale deployment to 0: %w", err)
+		}
+		log.Info("Suspended knight — scaled to 0", "knight", knight.Name)
+	}
+
+	return nil
+}
+
+// Resume scales the Knight's Deployment to 1 replica.
+func (b *DeploymentBackend) Resume(ctx context.Context, knight *aiv1alpha1.Knight) error {
+	log := logf.FromContext(ctx)
+
+	deploy := &appsv1.Deployment{}
+	err := b.Client.Get(ctx, types.NamespacedName{Name: knight.Name, Namespace: knight.Namespace}, deploy)
+	if apierrors.IsNotFound(err) {
+		return fmt.Errorf("deployment not found for resume: %s", knight.Name)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get deployment for resume: %w", err)
+	}
+
+	one := int32(1)
+	if deploy.Spec.Replicas == nil || *deploy.Spec.Replicas != one {
+		deploy.Spec.Replicas = &one
+		if err := b.Client.Update(ctx, deploy); err != nil {
+			return fmt.Errorf("failed to scale deployment to 1: %w", err)
+		}
+		log.Info("Resumed knight — scaled to 1", "knight", knight.Name)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

Refactors the Knight controller to use a pluggable `RuntimeBackend` interface for managing Knight runtime resources (Deployments). This enables future alternative backends (e.g., scale-to-zero Agent Sandbox).

## Changes

- **`pkg/runtime/backend.go`** — `RuntimeBackend` interface with `Reconcile`, `Cleanup`, `IsReady`, `Suspend`, `Resume`
- **`pkg/runtime/deployment_backend.go`** — `DeploymentBackend` implementing the interface, wrapping existing Deployment logic
- **`internal/controller/knight_controller.go`** — Updated to delegate to `RuntimeBackend` when set; falls back to inline reconciliation when nil
- **`cmd/main.go`** — Wires `DeploymentBackend` into `KnightReconciler` at startup
- **`api/v1alpha1/knight_types.go`** — Added `KnightLifecycle` type (`suspendPolicy`, `idleTimeout`) for future scale-to-zero support

## No behavioral changes

This is a pure refactor. All existing behavior is preserved:
- When `RuntimeBackend` is set → delegates to the backend
- When `RuntimeBackend` is nil → uses the original inline methods (backward compatible)

## Testing

- `go build ./...` ✅
- Unit tests pass (`internal/knight`, `internal/status`, `internal/util`, `pkg/nats`) ✅  
- Controller integration tests require envtest binaries (CI only)