### PR TITLE
test: add mission planner and assembler unit tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/gomega v1.38.2
 	github.com/prometheus/client_golang v1.23.2
 	github.com/robfig/cron/v3 v3.0.1
+	github.com/stretchr/testify v1.11.1
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
 	k8s.io/client-go v0.35.0
@@ -103,6 +104,7 @@ require (
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.35.0 // indirect
 	k8s.io/apiserver v0.35.0 // indirect
 	k8s.io/component-base v0.35.0 // indirect

--- a/internal/mission/mission_test.go
+++ b/internal/mission/mission_test.go
@@ -1,0 +1,415 @@
+package mission
+
+import (
+	"testing"
+
+	aiv1alpha1 "github.com/dapperdivers/roundtable/api/v1alpha1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ─── extractJSON ────────────────────────────────────────────────────────────
+
+func TestExtractJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "plain JSON",
+			input: `{"key":"value"}`,
+			want:  `{"key":"value"}`,
+		},
+		{
+			name:  "json code fence",
+			input: "some text\n```json\n{\"key\":\"value\"}\n```\nmore text",
+			want:  `{"key":"value"}`,
+		},
+		{
+			name:  "generic code fence",
+			input: "```\n{\"key\":\"value\"}\n```",
+			want:  `{"key":"value"}`,
+		},
+		{
+			name:  "whitespace around JSON",
+			input: "   {\"key\":\"value\"}   ",
+			want:  `{"key":"value"}`,
+		},
+		{
+			name:  "json fence with extra whitespace",
+			input: "```json\n  {\"a\":1}  \n```",
+			want:  `{"a":1}`,
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "text before json fence",
+			input: "Here is the plan:\n```json\n{\"plan\":true}\n```\nEnd.",
+			want:  `{"plan":true}`,
+		},
+		{
+			name:  "no closing fence after json tag",
+			input: "```json\n{\"open\":true}",
+			want:  `{"open":true}`,
+		},
+		{
+			name:  "nested fences - extracts first json block",
+			input: "```json\n{\"first\":1}\n```\n```json\n{\"second\":2}\n```",
+			want:  `{"first":1}`,
+		},
+		{
+			name:  "multiline JSON in fence",
+			input: "```json\n{\n  \"chains\": [],\n  \"knights\": []\n}\n```",
+			want:  "{\n  \"chains\": [],\n  \"knights\": []\n}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractJSON(tt.input)
+			if got != tt.want {
+				t.Errorf("extractJSON() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// ─── parsePlannerOutput ─────────────────────────────────────────────────────
+
+func TestParsePlannerOutput(t *testing.T) {
+	p := &Planner{}
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+		check   func(t *testing.T, po *PlannerOutput)
+	}{
+		{
+			name: "valid plan",
+			input: `{
+				"planVersion": "v1alpha1",
+				"metadata": {"objective": "test"},
+				"knights": [{"name": "k1", "role": "tester", "ephemeral": true}],
+				"chains": [{"name": "c1", "steps": [{"name": "s1", "knightRef": "k1", "task": "do it"}]}]
+			}`,
+			wantErr: false,
+			check: func(t *testing.T, po *PlannerOutput) {
+				if po.PlanVersion != "v1alpha1" {
+					t.Errorf("PlanVersion = %q, want v1alpha1", po.PlanVersion)
+				}
+				if po.Metadata.Objective != "test" {
+					t.Errorf("Objective = %q, want test", po.Metadata.Objective)
+				}
+				if len(po.Knights) != 1 {
+					t.Fatalf("Knights count = %d, want 1", len(po.Knights))
+				}
+				if po.Knights[0].Name != "k1" {
+					t.Errorf("Knight name = %q, want k1", po.Knights[0].Name)
+				}
+				if len(po.Chains) != 1 {
+					t.Fatalf("Chains count = %d, want 1", len(po.Chains))
+				}
+			},
+		},
+		{
+			name:    "invalid JSON",
+			input:   `{not json at all`,
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name: "JSON in markdown fence",
+			input: "```json\n" + `{"planVersion":"v1alpha1","metadata":{"objective":"fenced"}}` + "\n```",
+			wantErr: false,
+			check: func(t *testing.T, po *PlannerOutput) {
+				if po.Metadata.Objective != "fenced" {
+					t.Errorf("Objective = %q, want fenced", po.Metadata.Objective)
+				}
+			},
+		},
+		{
+			name: "minimal valid - empty arrays",
+			input: `{"planVersion":"v1alpha1","metadata":{"objective":"min"}}`,
+			wantErr: false,
+			check: func(t *testing.T, po *PlannerOutput) {
+				if len(po.Chains) != 0 {
+					t.Errorf("Chains count = %d, want 0", len(po.Chains))
+				}
+				if len(po.Knights) != 0 {
+					t.Errorf("Knights count = %d, want 0", len(po.Knights))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := p.parsePlannerOutput(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parsePlannerOutput() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && tt.check != nil {
+				tt.check(t, got)
+			}
+		})
+	}
+}
+
+// ─── sanitizeStepName ───────────────────────────────────────────────────────
+
+func TestSanitizeStepName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"no hyphens", "step_one", "step_one"},
+		{"single hyphen", "step-one", "step_one"},
+		{"multiple hyphens", "my-step-name", "my_step_name"},
+		{"all hyphens", "---", "___"},
+		{"empty", "", ""},
+		{"mixed", "a-b_c-d", "a_b_c_d"},
+		{"no change needed", "already_clean", "already_clean"},
+		{"leading hyphen", "-start", "_start"},
+		{"trailing hyphen", "end-", "end_"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeStepName(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeStepName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// ─── natsPrefix ─────────────────────────────────────────────────────────────
+
+func TestNatsPrefix(t *testing.T) {
+	tests := []struct {
+		name    string
+		mission *aiv1alpha1.Mission
+		want    string
+	}{
+		{
+			name: "custom prefix set",
+			mission: &aiv1alpha1.Mission{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-mission"},
+				Spec: aiv1alpha1.MissionSpec{
+					NATSPrefix: "custom-prefix",
+				},
+			},
+			want: "custom-prefix",
+		},
+		{
+			name: "no prefix - uses mission name",
+			mission: &aiv1alpha1.Mission{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-mission"},
+				Spec:       aiv1alpha1.MissionSpec{},
+			},
+			want: "mission-test-mission",
+		},
+		{
+			name: "empty prefix - uses mission name",
+			mission: &aiv1alpha1.Mission{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: aiv1alpha1.MissionSpec{
+					NATSPrefix: "",
+				},
+			},
+			want: "mission-foo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := natsPrefix(tt.mission)
+			if got != tt.want {
+				t.Errorf("natsPrefix() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// ─── sanitizeLabelValue ─────────────────────────────────────────────────────
+
+func TestSanitizeLabelValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"simple alpha", "researcher", "researcher"},
+		{"with spaces", "security researcher", "security-researcher"},
+		{"special chars", "role@#$name", "rolename"},
+		{"leading non-alphanum", "---start", "start"},
+		{"trailing non-alphanum", "end---", "end"},
+		{"both ends non-alphanum", "..middle..", "middle"},
+		{"empty", "", ""},
+		{"all invalid", "@#$%", ""},
+		{"with dots and dashes", "a.b-c_d", "a.b-c_d"},
+		{
+			name:  "truncate to 63 chars",
+			input: "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz01234567890",
+			want:  "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0",
+		},
+		{"uppercase preserved", "MyRole", "MyRole"},
+		{"numbers only", "123", "123"},
+		{"single char", "a", "a"},
+		{
+			name:  "spaces at ends after conversion",
+			input: " hello world ",
+			want:  "hello-world",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeLabelValue(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeLabelValue(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// ─── isAlphanumeric ─────────────────────────────────────────────────────────
+
+func TestIsAlphanumeric(t *testing.T) {
+	tests := []struct {
+		name  string
+		input byte
+		want  bool
+	}{
+		{"lowercase a", 'a', true},
+		{"lowercase z", 'z', true},
+		{"uppercase A", 'A', true},
+		{"uppercase Z", 'Z', true},
+		{"digit 0", '0', true},
+		{"digit 9", '9', true},
+		{"hyphen", '-', false},
+		{"underscore", '_', false},
+		{"dot", '.', false},
+		{"space", ' ', false},
+		{"at sign", '@', false},
+		{"exclamation", '!', false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAlphanumeric(tt.input)
+			if got != tt.want {
+				t.Errorf("isAlphanumeric(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// ─── buildMissionNetworkPolicy ──────────────────────────────────────────────
+
+func TestBuildMissionNetworkPolicy(t *testing.T) {
+	assembler := &KnightAssembler{}
+
+	mission := &aiv1alpha1.Mission{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-mission",
+			Namespace: "ai",
+			UID:       "test-uid-123",
+		},
+	}
+
+	policyName := "mission-test-mission-isolation"
+	policy := assembler.buildMissionNetworkPolicy(mission, policyName)
+
+	t.Run("metadata", func(t *testing.T) {
+		if policy.Name != policyName {
+			t.Errorf("Name = %q, want %q", policy.Name, policyName)
+		}
+		if policy.Namespace != "ai" {
+			t.Errorf("Namespace = %q, want ai", policy.Namespace)
+		}
+		if policy.Labels[aiv1alpha1.LabelMission] != "test-mission" {
+			t.Errorf("Mission label = %q, want test-mission", policy.Labels[aiv1alpha1.LabelMission])
+		}
+		if policy.Labels[aiv1alpha1.LabelEphemeral] != "true" {
+			t.Errorf("Ephemeral label = %q, want true", policy.Labels[aiv1alpha1.LabelEphemeral])
+		}
+	})
+
+	t.Run("owner reference", func(t *testing.T) {
+		if len(policy.OwnerReferences) != 1 {
+			t.Fatalf("OwnerReferences count = %d, want 1", len(policy.OwnerReferences))
+		}
+		ref := policy.OwnerReferences[0]
+		if ref.Name != "test-mission" {
+			t.Errorf("OwnerRef Name = %q, want test-mission", ref.Name)
+		}
+		if ref.Kind != "Mission" {
+			t.Errorf("OwnerRef Kind = %q, want Mission", ref.Kind)
+		}
+	})
+
+	t.Run("pod selector targets mission pods", func(t *testing.T) {
+		sel := policy.Spec.PodSelector
+		if sel.MatchLabels[aiv1alpha1.LabelMission] != "test-mission" {
+			t.Errorf("PodSelector mission label = %q, want test-mission",
+				sel.MatchLabels[aiv1alpha1.LabelMission])
+		}
+	})
+
+	t.Run("policy type is egress only", func(t *testing.T) {
+		if len(policy.Spec.PolicyTypes) != 1 {
+			t.Fatalf("PolicyTypes count = %d, want 1", len(policy.Spec.PolicyTypes))
+		}
+		if policy.Spec.PolicyTypes[0] != networkingv1.PolicyTypeEgress {
+			t.Errorf("PolicyType = %v, want Egress", policy.Spec.PolicyTypes[0])
+		}
+	})
+
+	t.Run("has three egress rules", func(t *testing.T) {
+		if len(policy.Spec.Egress) != 3 {
+			t.Fatalf("Egress rules count = %d, want 3 (NATS, DNS, HTTPS)", len(policy.Spec.Egress))
+		}
+	})
+
+	t.Run("NATS egress rule port 4222", func(t *testing.T) {
+		natsRule := policy.Spec.Egress[0]
+		if len(natsRule.Ports) != 1 {
+			t.Fatalf("NATS rule ports = %d, want 1", len(natsRule.Ports))
+		}
+		if natsRule.Ports[0].Port.IntValue() != 4222 {
+			t.Errorf("NATS port = %d, want 4222", natsRule.Ports[0].Port.IntValue())
+		}
+	})
+
+	t.Run("DNS egress rule ports 53 UDP and TCP", func(t *testing.T) {
+		dnsRule := policy.Spec.Egress[1]
+		if len(dnsRule.Ports) != 2 {
+			t.Fatalf("DNS rule ports = %d, want 2", len(dnsRule.Ports))
+		}
+	})
+
+	t.Run("HTTPS egress rule port 443", func(t *testing.T) {
+		httpsRule := policy.Spec.Egress[2]
+		if len(httpsRule.Ports) != 1 {
+			t.Fatalf("HTTPS rule ports = %d, want 1", len(httpsRule.Ports))
+		}
+		if httpsRule.Ports[0].Port.IntValue() != 443 {
+			t.Errorf("HTTPS port = %d, want 443", httpsRule.Ports[0].Port.IntValue())
+		}
+		// HTTPS rule has no peer restrictions (allows any destination)
+		if len(httpsRule.To) != 0 {
+			t.Errorf("HTTPS rule To peers = %d, want 0 (unrestricted)", len(httpsRule.To))
+		}
+	})
+}

--- a/pkg/runtime/deployment_backend_test.go
+++ b/pkg/runtime/deployment_backend_test.go
@@ -1,0 +1,368 @@
+/*
+Copyright 2026 dapperdivers.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	aiv1alpha1 "github.com/dapperdivers/roundtable/api/v1alpha1"
+)
+
+// newTestScheme builds a scheme with the types the deployment backend needs.
+func newTestScheme(t *testing.T) *k8sruntime.Scheme {
+	t.Helper()
+	s := k8sruntime.NewScheme()
+	require.NoError(t, aiv1alpha1.AddToScheme(s))
+	require.NoError(t, appsv1.AddToScheme(s))
+	require.NoError(t, corev1.AddToScheme(s))
+	return s
+}
+
+// stubPodSpecBuilder returns a minimal DeploymentSpec for testing.
+func stubPodSpecBuilder(_ context.Context, knight *aiv1alpha1.Knight) appsv1.DeploymentSpec {
+	image := knight.Spec.Image
+	if image == "" {
+		image = "ghcr.io/dapperdivers/openclaw-knight:latest"
+	}
+	return appsv1.DeploymentSpec{
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "knight",
+						Image: image,
+					},
+				},
+			},
+		},
+	}
+}
+
+// newTestKnight creates a minimal Knight CR for testing.
+func newTestKnight(name, namespace string) *aiv1alpha1.Knight {
+	return &aiv1alpha1.Knight{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "ai.roundtable.io/v1alpha1",
+			Kind:       "Knight",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			UID:       types.UID("test-uid-1234"),
+		},
+		Spec: aiv1alpha1.KnightSpec{
+			Domain: "security",
+			Model:  "claude-sonnet-4-20250514",
+			Image:  "ghcr.io/dapperdivers/openclaw-knight:v1",
+			Skills: []string{"recon", "vuln-scan"},
+			NATS: aiv1alpha1.KnightNATS{
+				Subject: "roundtable.security",
+			},
+		},
+	}
+}
+
+func TestNewDeploymentBackend(t *testing.T) {
+	s := newTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	b := NewDeploymentBackend(c, s, "default-image:latest", stubPodSpecBuilder)
+
+	assert.NotNil(t, b)
+	assert.Equal(t, "default-image:latest", b.DefaultImage)
+	assert.NotNil(t, b.BuildDeploymentSpec)
+	assert.NotNil(t, b.Client)
+	assert.NotNil(t, b.Scheme)
+}
+
+func TestDeploymentBackend_Reconcile_CreatesDeployment(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	b := NewDeploymentBackend(c, s, "default:latest", stubPodSpecBuilder)
+
+	knight := newTestKnight("percival", "ai")
+
+	err := b.Reconcile(ctx, knight)
+	require.NoError(t, err)
+
+	// Verify the deployment was created
+	deploy := &appsv1.Deployment{}
+	err = c.Get(ctx, types.NamespacedName{Name: "percival", Namespace: "ai"}, deploy)
+	require.NoError(t, err)
+
+	assert.Equal(t, "percival", deploy.Name)
+	assert.Equal(t, "ai", deploy.Namespace)
+	assert.Equal(t, int32(1), *deploy.Spec.Replicas)
+	assert.Equal(t, appsv1.RecreateDeploymentStrategyType, deploy.Spec.Strategy.Type)
+	assert.Equal(t, "security", deploy.Labels["roundtable.io/domain"])
+	assert.Equal(t, "knight", deploy.Labels["app.kubernetes.io/name"])
+	assert.Equal(t, "ghcr.io/dapperdivers/openclaw-knight:v1", deploy.Spec.Template.Spec.Containers[0].Image)
+
+	// Verify pod annotations
+	annos := deploy.Spec.Template.Annotations
+	assert.Equal(t, "claude-sonnet-4-20250514", annos["roundtable.io/model"])
+	assert.Equal(t, "recon,vuln-scan", annos["roundtable.io/skills"])
+	assert.Contains(t, annos, specHashAnnotation)
+}
+
+func TestDeploymentBackend_Reconcile_UpdatesOnSpecChange(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	b := NewDeploymentBackend(c, s, "default:latest", stubPodSpecBuilder)
+
+	knight := newTestKnight("percival", "ai")
+
+	// First reconcile — creates
+	require.NoError(t, b.Reconcile(ctx, knight))
+
+	deploy := &appsv1.Deployment{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "percival", Namespace: "ai"}, deploy))
+	originalHash := deploy.Spec.Template.Annotations[specHashAnnotation]
+	assert.NotEmpty(t, originalHash)
+
+	// Change the image → different spec hash
+	knight.Spec.Image = "ghcr.io/dapperdivers/openclaw-knight:v2"
+
+	require.NoError(t, b.Reconcile(ctx, knight))
+
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "percival", Namespace: "ai"}, deploy))
+	newHash := deploy.Spec.Template.Annotations[specHashAnnotation]
+	assert.NotEqual(t, originalHash, newHash, "spec hash should change when image changes")
+	assert.Equal(t, "ghcr.io/dapperdivers/openclaw-knight:v2", deploy.Spec.Template.Spec.Containers[0].Image)
+}
+
+func TestDeploymentBackend_Reconcile_SkipsWhenHashUnchanged(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	b := NewDeploymentBackend(c, s, "default:latest", stubPodSpecBuilder)
+
+	knight := newTestKnight("percival", "ai")
+
+	require.NoError(t, b.Reconcile(ctx, knight))
+
+	deploy := &appsv1.Deployment{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "percival", Namespace: "ai"}, deploy))
+	rv1 := deploy.ResourceVersion
+
+	// Reconcile again with same spec
+	require.NoError(t, b.Reconcile(ctx, knight))
+
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "percival", Namespace: "ai"}, deploy))
+	// Resource version should be the same since nothing changed
+	assert.Equal(t, rv1, deploy.ResourceVersion, "resource version should not change when spec is identical")
+}
+
+func TestDeploymentBackend_Cleanup_DeletesDeployment(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+	knight := newTestKnight("percival", "ai")
+
+	// Pre-create a deployment
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "percival",
+			Namespace: "ai",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(deploy).Build()
+	b := NewDeploymentBackend(c, s, "default:latest", stubPodSpecBuilder)
+
+	err := b.Cleanup(ctx, knight)
+	require.NoError(t, err)
+
+	// Deployment should be gone
+	err = c.Get(ctx, types.NamespacedName{Name: "percival", Namespace: "ai"}, &appsv1.Deployment{})
+	assert.True(t, err != nil, "deployment should be deleted")
+}
+
+func TestDeploymentBackend_Cleanup_NotFoundIsOK(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	b := NewDeploymentBackend(c, s, "default:latest", stubPodSpecBuilder)
+
+	knight := newTestKnight("ghost", "ai")
+	err := b.Cleanup(ctx, knight)
+	assert.NoError(t, err, "cleanup of non-existent deployment should not error")
+}
+
+func TestDeploymentBackend_IsReady_TrueWhenAvailable(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "percival", Namespace: "ai"},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+			},
+		},
+		Status: appsv1.DeploymentStatus{
+			ReadyReplicas: 1,
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(deploy).WithStatusSubresource(deploy).Build()
+	b := NewDeploymentBackend(c, s, "default:latest", stubPodSpecBuilder)
+
+	knight := newTestKnight("percival", "ai")
+	ready, err := b.IsReady(ctx, knight)
+	require.NoError(t, err)
+	assert.True(t, ready)
+}
+
+func TestDeploymentBackend_IsReady_FalseWhenNotFound(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	b := NewDeploymentBackend(c, s, "default:latest", stubPodSpecBuilder)
+
+	knight := newTestKnight("ghost", "ai")
+	ready, err := b.IsReady(ctx, knight)
+	require.NoError(t, err)
+	assert.False(t, ready)
+}
+
+func TestDeploymentBackend_IsReady_FalseWhenZeroReplicas(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "percival", Namespace: "ai"},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+			},
+		},
+		Status: appsv1.DeploymentStatus{
+			ReadyReplicas: 0,
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(deploy).WithStatusSubresource(deploy).Build()
+	b := NewDeploymentBackend(c, s, "default:latest", stubPodSpecBuilder)
+
+	knight := newTestKnight("percival", "ai")
+	ready, err := b.IsReady(ctx, knight)
+	require.NoError(t, err)
+	assert.False(t, ready)
+}
+
+func TestDeploymentBackend_Suspend_ScalesToZero(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+
+	one := int32(1)
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "percival", Namespace: "ai"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &one,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(deploy).Build()
+	b := NewDeploymentBackend(c, s, "default:latest", stubPodSpecBuilder)
+
+	knight := newTestKnight("percival", "ai")
+	err := b.Suspend(ctx, knight)
+	require.NoError(t, err)
+
+	updated := &appsv1.Deployment{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "percival", Namespace: "ai"}, updated))
+	assert.Equal(t, int32(0), *updated.Spec.Replicas)
+}
+
+func TestDeploymentBackend_Suspend_NotFoundIsOK(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	b := NewDeploymentBackend(c, s, "default:latest", stubPodSpecBuilder)
+
+	knight := newTestKnight("ghost", "ai")
+	err := b.Suspend(ctx, knight)
+	assert.NoError(t, err)
+}
+
+func TestDeploymentBackend_Resume_ScalesToOne(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+
+	zero := int32(0)
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "percival", Namespace: "ai"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &zero,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(deploy).Build()
+	b := NewDeploymentBackend(c, s, "default:latest", stubPodSpecBuilder)
+
+	knight := newTestKnight("percival", "ai")
+	err := b.Resume(ctx, knight)
+	require.NoError(t, err)
+
+	updated := &appsv1.Deployment{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "percival", Namespace: "ai"}, updated))
+	assert.Equal(t, int32(1), *updated.Spec.Replicas)
+}
+
+func TestDeploymentBackend_Resume_ErrorsWhenNotFound(t *testing.T) {
+	ctx := context.Background()
+	s := newTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	b := NewDeploymentBackend(c, s, "default:latest", stubPodSpecBuilder)
+
+	knight := newTestKnight("ghost", "ai")
+	err := b.Resume(ctx, knight)
+	assert.Error(t, err, "resume should error when deployment not found")
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/pkg/runtime/sandbox_backend_test.go
+++ b/pkg/runtime/sandbox_backend_test.go
@@ -1,0 +1,301 @@
+/*
+Copyright 2026 dapperdivers.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	aiv1alpha1 "github.com/dapperdivers/roundtable/api/v1alpha1"
+	sandboxv1alpha1 "sigs.k8s.io/agent-sandbox/api/v1alpha1"
+)
+
+// newSandboxTestScheme builds a scheme including sandbox types.
+func newSandboxTestScheme(t *testing.T) *k8sruntime.Scheme {
+	t.Helper()
+	s := k8sruntime.NewScheme()
+	require.NoError(t, aiv1alpha1.AddToScheme(s))
+	require.NoError(t, sandboxv1alpha1.AddToScheme(s))
+	require.NoError(t, corev1.AddToScheme(s))
+	return s
+}
+
+// stubSandboxPodSpecBuilder returns a minimal PodSpec for testing.
+func stubSandboxPodSpecBuilder(_ context.Context, knight *aiv1alpha1.Knight) corev1.PodSpec {
+	image := knight.Spec.Image
+	if image == "" {
+		image = "ghcr.io/dapperdivers/openclaw-knight:latest"
+	}
+	return corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:  "knight",
+				Image: image,
+			},
+		},
+	}
+}
+
+func TestNewSandboxBackend(t *testing.T) {
+	s := newSandboxTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	b := NewSandboxBackend(c, s, "default-image:latest", stubSandboxPodSpecBuilder)
+
+	assert.NotNil(t, b)
+	assert.Equal(t, "default-image:latest", b.DefaultImage)
+	assert.NotNil(t, b.BuildPodSpec)
+	assert.NotNil(t, b.Client)
+	assert.NotNil(t, b.Scheme)
+}
+
+func TestSandboxBackend_Reconcile_CreatesSandbox(t *testing.T) {
+	ctx := context.Background()
+	s := newSandboxTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	b := NewSandboxBackend(c, s, "default:latest", stubSandboxPodSpecBuilder)
+
+	knight := newTestKnight("gawain", "ai")
+
+	err := b.Reconcile(ctx, knight)
+	require.NoError(t, err)
+
+	sandbox := &sandboxv1alpha1.Sandbox{}
+	err = c.Get(ctx, types.NamespacedName{Name: "gawain", Namespace: "ai"}, sandbox)
+	require.NoError(t, err)
+
+	assert.Equal(t, "gawain", sandbox.Name)
+	assert.Equal(t, "ai", sandbox.Namespace)
+	assert.Equal(t, int32(1), *sandbox.Spec.Replicas)
+	assert.Equal(t, "knight", sandbox.Labels["app.kubernetes.io/name"])
+	assert.Equal(t, "gawain", sandbox.Labels["app.kubernetes.io/instance"])
+	assert.Equal(t, "roundtable-operator", sandbox.Labels["app.kubernetes.io/managed-by"])
+	assert.Equal(t, "security", sandbox.Labels["roundtable.io/domain"])
+	assert.Equal(t, "ghcr.io/dapperdivers/openclaw-knight:v1", sandbox.Spec.PodTemplate.Spec.Containers[0].Image)
+}
+
+func TestSandboxBackend_Cleanup_DeletesSandbox(t *testing.T) {
+	ctx := context.Background()
+	s := newSandboxTestScheme(t)
+
+	sandbox := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "gawain", Namespace: "ai"},
+		Spec: sandboxv1alpha1.SandboxSpec{
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(sandbox).Build()
+	b := NewSandboxBackend(c, s, "default:latest", stubSandboxPodSpecBuilder)
+
+	knight := newTestKnight("gawain", "ai")
+	err := b.Cleanup(ctx, knight)
+	require.NoError(t, err)
+
+	err = c.Get(ctx, types.NamespacedName{Name: "gawain", Namespace: "ai"}, &sandboxv1alpha1.Sandbox{})
+	assert.True(t, err != nil, "sandbox should be deleted")
+}
+
+func TestSandboxBackend_Cleanup_NotFoundIsOK(t *testing.T) {
+	ctx := context.Background()
+	s := newSandboxTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	b := NewSandboxBackend(c, s, "default:latest", stubSandboxPodSpecBuilder)
+
+	knight := newTestKnight("ghost", "ai")
+	err := b.Cleanup(ctx, knight)
+	assert.NoError(t, err)
+}
+
+func TestSandboxBackend_IsReady_TrueWithReadyCondition(t *testing.T) {
+	ctx := context.Background()
+	s := newSandboxTestScheme(t)
+
+	sandbox := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "gawain", Namespace: "ai"},
+		Spec: sandboxv1alpha1.SandboxSpec{
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+			},
+		},
+		Status: sandboxv1alpha1.SandboxStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:   string(sandboxv1alpha1.SandboxConditionReady),
+					Status: metav1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(sandbox).WithStatusSubresource(sandbox).Build()
+	b := NewSandboxBackend(c, s, "default:latest", stubSandboxPodSpecBuilder)
+
+	knight := newTestKnight("gawain", "ai")
+	ready, err := b.IsReady(ctx, knight)
+	require.NoError(t, err)
+	assert.True(t, ready)
+}
+
+func TestSandboxBackend_IsReady_FalseWhenNotFound(t *testing.T) {
+	ctx := context.Background()
+	s := newSandboxTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	b := NewSandboxBackend(c, s, "default:latest", stubSandboxPodSpecBuilder)
+
+	knight := newTestKnight("ghost", "ai")
+	ready, err := b.IsReady(ctx, knight)
+	require.NoError(t, err)
+	assert.False(t, ready)
+}
+
+func TestSandboxBackend_IsReady_FallbackToReplicas(t *testing.T) {
+	ctx := context.Background()
+	s := newSandboxTestScheme(t)
+
+	sandbox := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "gawain", Namespace: "ai"},
+		Spec: sandboxv1alpha1.SandboxSpec{
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+			},
+		},
+		Status: sandboxv1alpha1.SandboxStatus{
+			Replicas: 1,
+			// No Ready condition set
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(sandbox).WithStatusSubresource(sandbox).Build()
+	b := NewSandboxBackend(c, s, "default:latest", stubSandboxPodSpecBuilder)
+
+	knight := newTestKnight("gawain", "ai")
+	ready, err := b.IsReady(ctx, knight)
+	require.NoError(t, err)
+	assert.True(t, ready)
+}
+
+func TestSandboxBackend_Suspend_ScalesToZero(t *testing.T) {
+	ctx := context.Background()
+	s := newSandboxTestScheme(t)
+
+	sandbox := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "gawain", Namespace: "ai"},
+		Spec: sandboxv1alpha1.SandboxSpec{
+			Replicas: ptr.To(int32(1)),
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(sandbox).Build()
+	b := NewSandboxBackend(c, s, "default:latest", stubSandboxPodSpecBuilder)
+
+	knight := newTestKnight("gawain", "ai")
+	err := b.Suspend(ctx, knight)
+	require.NoError(t, err)
+
+	updated := &sandboxv1alpha1.Sandbox{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "gawain", Namespace: "ai"}, updated))
+	assert.Equal(t, int32(0), *updated.Spec.Replicas)
+}
+
+func TestSandboxBackend_Suspend_NotFoundIsOK(t *testing.T) {
+	ctx := context.Background()
+	s := newSandboxTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	b := NewSandboxBackend(c, s, "default:latest", stubSandboxPodSpecBuilder)
+
+	knight := newTestKnight("ghost", "ai")
+	err := b.Suspend(ctx, knight)
+	assert.NoError(t, err)
+}
+
+func TestSandboxBackend_Resume_ScalesToOne(t *testing.T) {
+	ctx := context.Background()
+	s := newSandboxTestScheme(t)
+
+	sandbox := &sandboxv1alpha1.Sandbox{
+		ObjectMeta: metav1.ObjectMeta{Name: "gawain", Namespace: "ai"},
+		Spec: sandboxv1alpha1.SandboxSpec{
+			Replicas: ptr.To(int32(0)),
+			PodTemplate: sandboxv1alpha1.PodTemplate{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+			},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(sandbox).Build()
+	b := NewSandboxBackend(c, s, "default:latest", stubSandboxPodSpecBuilder)
+
+	knight := newTestKnight("gawain", "ai")
+	err := b.Resume(ctx, knight)
+	require.NoError(t, err)
+
+	updated := &sandboxv1alpha1.Sandbox{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "gawain", Namespace: "ai"}, updated))
+	assert.Equal(t, int32(1), *updated.Spec.Replicas)
+}
+
+func TestSandboxBackend_Resume_ErrorsWhenNotFound(t *testing.T) {
+	ctx := context.Background()
+	s := newSandboxTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	b := NewSandboxBackend(c, s, "default:latest", stubSandboxPodSpecBuilder)
+
+	knight := newTestKnight("ghost", "ai")
+	err := b.Resume(ctx, knight)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestSandboxBackend_BuildVolumeClaimTemplates_NilWhenExistingClaim(t *testing.T) {
+	s := newSandboxTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	b := NewSandboxBackend(c, s, "default:latest", stubSandboxPodSpecBuilder)
+
+	knight := newTestKnight("gawain", "ai")
+	knight.Spec.Workspace = &aiv1alpha1.KnightWorkspace{
+		ExistingClaim: "my-pvc",
+	}
+
+	templates := b.buildVolumeClaimTemplates(knight)
+	assert.Nil(t, templates)
+}
+
+func TestSandboxBackend_BuildVolumeClaimTemplates_NilWhenNoWorkspace(t *testing.T) {
+	s := newSandboxTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	b := NewSandboxBackend(c, s, "default:latest", stubSandboxPodSpecBuilder)
+
+	knight := newTestKnight("gawain", "ai")
+	knight.Spec.Workspace = nil
+
+	templates := b.buildVolumeClaimTemplates(knight)
+	assert.Nil(t, templates)
+}


### PR DESCRIPTION
Pure-logic unit tests for internal/mission package.

## Functions tested (table-driven, 40 test cases):

### planner.go
- `extractJSON` — markdown fence extraction (10 cases)
- `parsePlannerOutput` — JSON parsing with fence handling (5 cases)
- `sanitizeStepName` — hyphen-to-underscore conversion (9 cases)
- `natsPrefix` — NATS subject prefix resolution (3 cases)

### assembler.go
- `sanitizeLabelValue` — K8s label sanitization (14 cases)
- `isAlphanumeric` — character classification (12 cases)
- `buildMissionNetworkPolicy` — NetworkPolicy construction (8 subtests)