### PR TITLE
fix: undefined log in chain controller validation

### DIFF
--- a/internal/controller/chain_controller.go
+++ b/internal/controller/chain_controller.go
@@ -82,6 +82,8 @@ func (r *ChainReconciler) natsClient() (natspkg.Client, error) {
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
 func (r *ChainReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+	
 	chain := &aiv1alpha1.Chain{}
 	if err := r.Get(ctx, req.NamespacedName, chain); err != nil {
 		if client.IgnoreNotFound(err) == nil {
@@ -202,7 +204,6 @@ func (r *ChainReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	// Reset to Idle when spec changes (generation drift) and chain is not running
 	if chain.Status.ObservedGeneration != chain.Generation &&
 		chain.Status.Phase != aiv1alpha1.ChainPhaseRunning {
-		log := logf.FromContext(ctx)
 		log.Info("Spec changed, resetting chain to Idle",
 			"oldGen", chain.Status.ObservedGeneration,
 			"newGen", chain.Generation)


### PR DESCRIPTION
Fixes build error where log variable was used before declaration in 4 validation error handlers (lines 123, 139, 155, 171).

## Changes
- Moved `log := logf.FromContext(ctx)` to the beginning of the Reconcile function
- Removed duplicate log declaration later in the function

This ensures the log variable is available for all error handlers that need it during validation.