### PR TITLE
feat: build knight Nix tools into a shared store via operator Jobs

### DIFF
--- a/api/v1alpha1/knight_types.go
+++ b/api/v1alpha1/knight_types.go
@@ -354,6 +354,12 @@ type KnightStatus struct {
 	// +optional
 	NATSConsumer string `json:"natsConsumer,omitempty"`
 
+	// nixToolsHash is the tools hash whose flake has been successfully built
+	// and published to the shared Nix store. Empty until the first build
+	// completes; used to avoid rebuilding unchanged tool sets.
+	// +optional
+	NixToolsHash string `json:"nixToolsHash,omitempty"`
+
 	// observedGeneration is the most recent generation observed by the controller.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`

--- a/charts/roundtable-operator/Chart.yaml
+++ b/charts/roundtable-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: roundtable-operator
 description: Knights of the Round Table — A Kubernetes Operator for Multi-Agent AI Orchestration
 type: application
-version: 0.9.0
+version: 0.10.0
 appVersion: "1.0.0"
 keywords:
   - ai

--- a/charts/roundtable-operator/crds/ai.roundtable.io_knights.yaml
+++ b/charts/roundtable-operator/crds/ai.roundtable.io_knights.yaml
@@ -631,6 +631,12 @@ spec:
                 description: natsConsumer is the name of the reconciled NATS durable
                   consumer.
                 type: string
+              nixToolsHash:
+                description: |-
+                  nixToolsHash is the tools hash whose flake has been successfully built
+                  and published to the shared Nix store. Empty until the first build
+                  completes; used to avoid rebuilding unchanged tool sets.
+                type: string
               observedGeneration:
                 description: observedGeneration is the most recent generation observed
                   by the controller.

--- a/charts/roundtable-operator/templates/rbac.yaml
+++ b/charts/roundtable-operator/templates/rbac.yaml
@@ -25,6 +25,10 @@ rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Managed resources — Nix build Jobs (shared store)
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   # Managed resources — Agent Sandbox
   - apiGroups: ["agents.x-k8s.io"]
     resources: ["sandboxes", "sandboxes/status"]

--- a/config/crd/bases/ai.roundtable.io_knights.yaml
+++ b/config/crd/bases/ai.roundtable.io_knights.yaml
@@ -631,6 +631,12 @@ spec:
                 description: natsConsumer is the name of the reconciled NATS durable
                   consumer.
                 type: string
+              nixToolsHash:
+                description: |-
+                  nixToolsHash is the tools hash whose flake has been successfully built
+                  and published to the shared Nix store. Empty until the first build
+                  completes; used to avoid rebuilding unchanged tool sets.
+                type: string
               observedGeneration:
                 description: observedGeneration is the most recent generation observed
                   by the controller.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -81,6 +81,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - networking.k8s.io
   resources:
   - networkpolicies

--- a/internal/controller/chain_controller.go
+++ b/internal/controller/chain_controller.go
@@ -88,7 +88,7 @@ func (r *ChainReconciler) natsClient() (natspkg.Client, error) {
 
 func (r *ChainReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
-	
+
 	chain := &aiv1alpha1.Chain{}
 	if err := r.Get(ctx, req.NamespacedName, chain); err != nil {
 		if client.IgnoreNotFound(err) == nil {
@@ -481,8 +481,8 @@ func (r *ChainReconciler) reconcileRunning(ctx context.Context, chain *aiv1alpha
 					}
 
 					// Truncate CRD status output to avoid etcd bloat (4000 chars allows
-				// meaningful summaries for template resolution while staying well
-				// under etcd's 1.5MB object limit — 10 steps × 4KB = 40KB max)
+					// meaningful summaries for template resolution while staying well
+					// under etcd's 1.5MB object limit — 10 steps × 4KB = 40KB max)
 					if len(ss.Output) > 4000 {
 						ss.Output = ss.Output[:4000] + "\n\n... [truncated — full output in NATS KV bucket 'chain-outputs', key '" + chain.Name + "." + ss.Name + "']"
 					}

--- a/internal/controller/knight_controller.go
+++ b/internal/controller/knight_controller.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -72,6 +73,7 @@ type KnightReconciler struct {
 // +kubebuilder:rbac:groups=ai.roundtable.io,resources=knights/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=ai.roundtable.io,resources=knights/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
@@ -152,6 +154,12 @@ func (r *KnightReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err := r.reconcilePVC(ctx, knight); err != nil {
 		reconcileErr = err
 		log.Error(err, "Failed to reconcile PVC")
+	}
+
+	// 2b. Nix build Job (shared store) — no-op unless the shared store exists
+	if err := r.reconcileNixBuildJob(ctx, knight); err != nil {
+		reconcileErr = err
+		log.Error(err, "Failed to reconcile Nix build Job")
 	}
 
 	// 3. Runtime (Deployment or Sandbox, depending on knight.Spec.Runtime)
@@ -723,6 +731,7 @@ func (r *KnightReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&aiv1alpha1.Knight{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
+		Owns(&batchv1.Job{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&sandboxv1alpha1.Sandbox{}).
 		Named("knight").

--- a/internal/controller/knight_controller_test.go
+++ b/internal/controller/knight_controller_test.go
@@ -85,8 +85,8 @@ var _ = Describe("Knight Controller", func() {
 		It("should successfully reconcile the resource", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &KnightReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
 				Recorder: record.NewFakeRecorder(100),
 			}
 
@@ -103,8 +103,8 @@ var _ = Describe("Knight Controller", func() {
 
 		It("should create a ConfigMap with knight configuration", func() {
 			controllerReconciler := &KnightReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
 				Recorder: record.NewFakeRecorder(100),
 			}
 
@@ -125,8 +125,8 @@ var _ = Describe("Knight Controller", func() {
 
 		It("should create a PVC for the knight workspace", func() {
 			controllerReconciler := &KnightReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
 				Recorder: record.NewFakeRecorder(100),
 			}
 
@@ -143,8 +143,8 @@ var _ = Describe("Knight Controller", func() {
 
 		It("should create a Deployment with correct containers", func() {
 			controllerReconciler := &KnightReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
 				Recorder: record.NewFakeRecorder(100),
 			}
 
@@ -217,8 +217,8 @@ var _ = Describe("Knight Controller", func() {
 		BeforeEach(func() {
 			ctx = context.Background()
 			reconciler = &KnightReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
 				Recorder: record.NewFakeRecorder(100),
 			}
 			knightName = "test-runtime-transition"
@@ -348,8 +348,8 @@ var _ = Describe("Knight Controller", func() {
 		BeforeEach(func() {
 			ctx = context.Background()
 			reconciler = &KnightReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
 				Recorder: record.NewFakeRecorder(100),
 			}
 			knightName = "test-nix-cleanup"

--- a/internal/controller/knight_nixbuild.go
+++ b/internal/controller/knight_nixbuild.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2026 dapperdivers.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	aiv1alpha1 "github.com/dapperdivers/roundtable/api/v1alpha1"
+	knightpkg "github.com/dapperdivers/roundtable/internal/knight"
+)
+
+// sharedNixStorePVCName is the cluster-wide RWX PVC backing the shared Nix
+// store. The build Job mounts it read-write; knight pods mount it read-only.
+// Provisioned out-of-band via GitOps; the build feature is inert until it exists.
+const sharedNixStorePVCName = "roundtable-nix-store"
+
+// nixBuildJobTTL keeps finished build Jobs around briefly for log inspection
+// before Kubernetes garbage-collects them.
+const nixBuildJobTTL int32 = 3600
+
+// reconcileNixBuildJob ensures the knight's flake tools are built into the
+// shared Nix store. It is a no-op unless the shared store PVC exists, so the
+// operator can ship this ahead of the PVC and activate automatically once
+// GitOps creates it. Builds are gated on the nix-tools hash: a knight whose
+// tool set is already published (status.nixToolsHash) triggers no Job.
+func (r *KnightReconciler) reconcileNixBuildJob(ctx context.Context, knight *aiv1alpha1.Knight) error {
+	log := logf.FromContext(ctx)
+
+	hasNixTools := (knight.Spec.Tools != nil && len(knight.Spec.Tools.Nix) > 0) || len(knight.Spec.NixPackages) > 0
+	if !hasNixTools {
+		return nil
+	}
+
+	// Cheap check first: nothing to do if the current tool set is already built.
+	currentHash := knightpkg.NixToolsHash(knight)
+	if knight.Status.NixToolsHash == currentHash {
+		return nil // already published
+	}
+
+	// Feature gate: only act when the shared store exists.
+	shared := &corev1.PersistentVolumeClaim{}
+	if err := r.Get(ctx, types.NamespacedName{Name: sharedNixStorePVCName, Namespace: knight.Namespace}, shared); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil // shared store not provisioned yet — legacy per-pod build still applies
+		}
+		return fmt.Errorf("shared Nix store lookup failed: %w", err)
+	}
+
+	jobName := fmt.Sprintf("%s-nixbuild-%s", knight.Name, currentHash)
+	job := &batchv1.Job{}
+	err := r.Get(ctx, types.NamespacedName{Name: jobName, Namespace: knight.Namespace}, job)
+
+	if apierrors.IsNotFound(err) {
+		newJob := r.buildNixBuildJob(knight, currentHash, jobName)
+		if err := controllerutil.SetControllerReference(knight, newJob, r.Scheme); err != nil {
+			return err
+		}
+		if err := r.Create(ctx, newJob); err != nil {
+			return fmt.Errorf("nix build Job create failed: %w", err)
+		}
+		log.Info("Nix build Job created", "job", jobName, "toolsHash", currentHash)
+		r.Recorder.Eventf(knight, corev1.EventTypeNormal, "NixBuildStarted", "Building Nix tools (hash %s) into shared store", currentHash)
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("nix build Job get failed: %w", err)
+	}
+
+	// Job exists — react to its terminal state.
+	switch {
+	case job.Status.Succeeded > 0:
+		knight.Status.NixToolsHash = currentHash // persisted by updateStatus
+		log.Info("Nix build Job succeeded", "job", jobName, "toolsHash", currentHash)
+		r.Recorder.Eventf(knight, corev1.EventTypeNormal, "NixBuildComplete", "Nix tools (hash %s) published to shared store", currentHash)
+	case job.Spec.BackoffLimit != nil && job.Status.Failed > *job.Spec.BackoffLimit:
+		r.Recorder.Eventf(knight, corev1.EventTypeWarning, "NixBuildFailed", "Nix build Job %s failed; tools not published", jobName)
+	}
+	return nil
+}
+
+// buildNixBuildJob constructs the per-knight Nix build Job. It runs the
+// pi-knight image's nix-build.sh with the shared store mounted RW and the
+// knight's flake ConfigMap at /config. TMPDIR is an emptyDir so build scratch
+// never touches the shared store.
+func (r *KnightReconciler) buildNixBuildJob(knight *aiv1alpha1.Knight, hash, jobName string) *batchv1.Job {
+	image := knight.Spec.Image
+	if image == "" {
+		image = r.DefaultImage
+	}
+	if image == "" {
+		image = "ghcr.io/dapperdivers/pi-knight:latest"
+	}
+
+	labels := map[string]string{
+		"app.kubernetes.io/name":       "knight-nixbuild",
+		"app.kubernetes.io/instance":   knight.Name,
+		"app.kubernetes.io/managed-by": "roundtable-operator",
+		"roundtable.io/purpose":        "nix-build",
+	}
+
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: knight.Namespace,
+			Labels:    labels,
+			Annotations: map[string]string{
+				nixToolsHashAnnotation: hash,
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit:            ptr.To(int32(2)),
+			TTLSecondsAfterFinished: ptr.To(nixBuildJobTTL),
+			ActiveDeadlineSeconds:   ptr.To(int64(1800)),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					Containers: []corev1.Container{
+						{
+							Name:    "nixbuild",
+							Image:   image,
+							Command: []string{"/app/scripts/nix-build.sh"},
+							Env: []corev1.EnvVar{
+								// Lowercase CR name — matches the profile key
+								// the knight pod derives from KNIGHT_NAME.
+								{Name: "KNIGHT_NAME", Value: knight.Name},
+								{Name: "FLAKE_FILE", Value: "/config/flake.nix"},
+								{Name: "TMPDIR", Value: "/scratch"},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "nix", MountPath: "/nix"},
+								{Name: "config", MountPath: "/config"},
+								{Name: "scratch", MountPath: "/scratch"},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "nix",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: sharedNixStorePVCName,
+								},
+							},
+						},
+						{
+							Name: "config",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: fmt.Sprintf("knight-%s-config", knight.Name),
+									},
+								},
+							},
+						},
+						{
+							Name:         "scratch",
+							VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/controller/knight_nixbuild_test.go
+++ b/internal/controller/knight_nixbuild_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2026 dapperdivers.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	aiv1alpha1 "github.com/dapperdivers/roundtable/api/v1alpha1"
+	knightpkg "github.com/dapperdivers/roundtable/internal/knight"
+)
+
+var _ = Describe("Knight Nix build Job", func() {
+	newKnight := func(name string, tools []string) *aiv1alpha1.Knight {
+		return &aiv1alpha1.Knight{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: aiv1alpha1.KnightSpec{
+				Domain: "security",
+				Tools:  &aiv1alpha1.KnightTools{Nix: tools},
+			},
+		}
+	}
+
+	// ── buildNixBuildJob (pure) ───────────────────────────────────────────
+	Describe("buildNixBuildJob", func() {
+		It("mounts the shared store, knight ConfigMap, and a scratch emptyDir", func() {
+			r := &KnightReconciler{DefaultImage: "ghcr.io/dapperdivers/pi-knight:test"}
+			k := newKnight("galahad", []string{"nmap"})
+			job := r.buildNixBuildJob(k, "abc123", "galahad-nixbuild-abc123")
+
+			pod := job.Spec.Template.Spec
+			Expect(pod.RestartPolicy).To(Equal(corev1.RestartPolicyNever))
+			Expect(pod.Containers).To(HaveLen(1))
+
+			c := pod.Containers[0]
+			Expect(c.Image).To(Equal("ghcr.io/dapperdivers/pi-knight:test"))
+			Expect(c.Command).To(Equal([]string{"/app/scripts/nix-build.sh"}))
+
+			// shared store mounted RW (no ReadOnly flag), config + scratch present
+			mounts := map[string]corev1.VolumeMount{}
+			for _, m := range c.VolumeMounts {
+				mounts[m.Name] = m
+			}
+			Expect(mounts["nix"].MountPath).To(Equal("/nix"))
+			Expect(mounts["nix"].ReadOnly).To(BeFalse())
+			Expect(mounts["config"].MountPath).To(Equal("/config"))
+			Expect(mounts["scratch"].MountPath).To(Equal("/scratch"))
+
+			// KNIGHT_NAME is the lowercase CR name (profile key); TMPDIR off /nix
+			env := map[string]string{}
+			for _, e := range c.Env {
+				env[e.Name] = e.Value
+			}
+			Expect(env["KNIGHT_NAME"]).To(Equal("galahad"))
+			Expect(env["TMPDIR"]).To(Equal("/scratch"))
+
+			// volumes wired to the shared PVC and the knight's config CM
+			vols := map[string]corev1.Volume{}
+			for _, v := range pod.Volumes {
+				vols[v.Name] = v
+			}
+			Expect(vols["nix"].PersistentVolumeClaim.ClaimName).To(Equal(sharedNixStorePVCName))
+			Expect(vols["config"].ConfigMap.Name).To(Equal("knight-galahad-config"))
+			Expect(vols["scratch"].EmptyDir).NotTo(BeNil())
+		})
+	})
+
+	// ── reconcileNixBuildJob (envtest) ────────────────────────────────────
+	Describe("reconcileNixBuildJob", func() {
+		var r *KnightReconciler
+
+		BeforeEach(func() {
+			r = &KnightReconciler{
+				Client:       k8sClient,
+				Scheme:       k8sClient.Scheme(),
+				Recorder:     record.NewFakeRecorder(10),
+				DefaultImage: "ghcr.io/dapperdivers/pi-knight:test",
+			}
+		})
+
+		It("is a no-op when the shared store PVC is absent", func() {
+			k := newKnight("gawain", []string{"jq"})
+			Expect(r.reconcileNixBuildJob(ctx, k)).To(Succeed())
+
+			jobs := &batchv1.JobList{}
+			Expect(k8sClient.List(ctx, jobs, client.InNamespace("default"))).To(Succeed())
+			for _, j := range jobs.Items {
+				Expect(j.Labels["app.kubernetes.io/instance"]).NotTo(Equal("gawain"))
+			}
+		})
+
+		It("creates a build Job once the shared store exists", func() {
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: sharedNixStorePVCName, Namespace: "default"},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, pvc)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, pvc) }()
+
+			// The knight need not be persisted — reconcileNixBuildJob works on
+			// the in-memory object and only creates the Job. A UID makes the
+			// owner reference well-formed.
+			k := newKnight("percival", []string{"nmap", "jq"})
+			k.UID = "percival-uid"
+
+			Expect(r.reconcileNixBuildJob(ctx, k)).To(Succeed())
+
+			hash := knightpkg.NixToolsHash(k)
+			job := &batchv1.Job{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "percival-nixbuild-" + hash,
+				Namespace: "default",
+			}, job)).To(Succeed())
+			Expect(job.Spec.Template.Spec.Containers[0].Command).To(ContainElement("/app/scripts/nix-build.sh"))
+		})
+
+		It("does nothing when the published hash already matches", func() {
+			k := newKnight("kay", []string{"curl"})
+			k.Status.NixToolsHash = knightpkg.NixToolsHash(k)
+			// No PVC needed — the hash-match short-circuits before the PVC check
+			Expect(r.reconcileNixBuildJob(ctx, k)).To(Succeed())
+		})
+	})
+})

--- a/internal/controller/mission_controller.go
+++ b/internal/controller/mission_controller.go
@@ -25,8 +25,8 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"

--- a/internal/controller/mission_controller_test.go
+++ b/internal/controller/mission_controller_test.go
@@ -171,7 +171,6 @@ var _ = Describe("Mission Controller", func() {
 		}
 	}
 
-
 	// driveToPhase reconciles until the mission reaches targetPhase or maxIter is exceeded.
 	// Optional beforeReconcile callback runs before each reconcile (e.g., to make knights ready).
 	driveToPhase := func(r *MissionReconciler, targetPhase aiv1alpha1.MissionPhase, maxIter int, beforeReconcile ...func(aiv1alpha1.MissionPhase)) {
@@ -275,9 +274,9 @@ var _ = Describe("Mission Controller", func() {
 
 	newReconciler := func() *MissionReconciler {
 		return &MissionReconciler{
-			Client: k8sClient,
-			Scheme: k8sClient.Scheme(),
-			Recorder: record.NewFakeRecorder(100),
+			Client:    k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			Recorder:  record.NewFakeRecorder(100),
 			Assembler: &missionpkg.KnightAssembler{Client: k8sClient, Scheme: k8sClient.Scheme()},
 		}
 	}
@@ -638,9 +637,9 @@ var _ = Describe("Mission Controller", func() {
 			createKnight()
 			createChain()
 			createMission(aiv1alpha1.MissionSpec{
-				Objective:      "Test result retention",
-				RetainResults:  true,
-				RoundTableRef:  "test-rt",
+				Objective:     "Test result retention",
+				RetainResults: true,
+				RoundTableRef: "test-rt",
 				Knights: []aiv1alpha1.MissionKnight{
 					{Name: knightName, Role: "tester"},
 				},
@@ -1023,11 +1022,11 @@ var _ = Describe("Mission Controller", func() {
 				Expect(k8sClient.Get(ctx, ephemeralKnightNN, knight)).To(Succeed())
 
 				// Verify overrides applied
-				Expect(knight.Spec.Model).To(Equal("claude-sonnet-4-20250514")) // Overridden
+				Expect(knight.Spec.Model).To(Equal("claude-sonnet-4-20250514"))      // Overridden
 				Expect(knight.Spec.Skills).To(ConsistOf("security", "custom-skill")) // Overridden
-				Expect(knight.Spec.Concurrency).To(Equal(int32(5))) // Overridden
-				Expect(knight.Spec.Domain).To(Equal("security")) // From template
-				Expect(knight.Spec.TaskTimeout).To(Equal(int32(600))) // From template
+				Expect(knight.Spec.Concurrency).To(Equal(int32(5)))                  // Overridden
+				Expect(knight.Spec.Domain).To(Equal("security"))                     // From template
+				Expect(knight.Spec.TaskTimeout).To(Equal(int32(600)))                // From template
 
 				// Verify environment variables added
 				found := false
@@ -1083,11 +1082,11 @@ var _ = Describe("Mission Controller", func() {
 				Expect(k8sClient.Get(ctx, ephemeralKnightNN, knight)).To(Succeed())
 
 				// Verify mission-level template values (not RoundTable template values)
-				Expect(knight.Spec.Domain).To(Equal("incident-response")) // From mission template
-				Expect(knight.Spec.Model).To(Equal("claude-opus-4-20250514")) // From mission template
+				Expect(knight.Spec.Domain).To(Equal("incident-response"))                  // From mission template
+				Expect(knight.Spec.Model).To(Equal("claude-opus-4-20250514"))              // From mission template
 				Expect(knight.Spec.Skills).To(ConsistOf("forensics", "incident-response")) // From mission template
-				Expect(knight.Spec.Concurrency).To(Equal(int32(10))) // From mission template
-				Expect(knight.Spec.TaskTimeout).To(Equal(int32(900))) // From mission template
+				Expect(knight.Spec.Concurrency).To(Equal(int32(10)))                       // From mission template
+				Expect(knight.Spec.TaskTimeout).To(Equal(int32(900)))                      // From mission template
 
 				// Should NOT have RoundTable template values
 				Expect(knight.Spec.Domain).NotTo(Equal("security"))
@@ -1437,7 +1436,7 @@ var _ = Describe("Mission Controller - Warm Pool", func() {
 					Name:      rtName + "-warm-ready",
 					Namespace: namespace,
 					Labels: map[string]string{
-						aiv1alpha1.LabelRoundTable: rtName,
+						aiv1alpha1.LabelRoundTable:      rtName,
 						aiv1alpha1.LabelWarmPool:        "true",
 						aiv1alpha1.LabelWarmPoolClaimed: "false",
 					},
@@ -1497,9 +1496,9 @@ var _ = Describe("Mission Controller - Warm Pool", func() {
 
 			By("Reconciling the mission to assembling phase")
 			reconciler := &MissionReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-				Recorder: record.NewFakeRecorder(100),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				Recorder:  record.NewFakeRecorder(100),
 				Assembler: &missionpkg.KnightAssembler{Client: k8sClient, Scheme: k8sClient.Scheme()},
 			}
 
@@ -1567,9 +1566,9 @@ var _ = Describe("Mission Controller - Warm Pool", func() {
 
 			By("Reconciling the mission")
 			reconciler := &MissionReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-				Recorder: record.NewFakeRecorder(100),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				Recorder:  record.NewFakeRecorder(100),
 				Assembler: &missionpkg.KnightAssembler{Client: k8sClient, Scheme: k8sClient.Scheme()},
 			}
 
@@ -1622,7 +1621,7 @@ var _ = Describe("Mission Controller - Warm Pool", func() {
 					Name:      rtName + "-warm-double",
 					Namespace: namespace,
 					Labels: map[string]string{
-						aiv1alpha1.LabelRoundTable: rtName,
+						aiv1alpha1.LabelRoundTable:      rtName,
 						aiv1alpha1.LabelWarmPool:        "true",
 						aiv1alpha1.LabelWarmPoolClaimed: "false",
 					},
@@ -1687,9 +1686,9 @@ var _ = Describe("Mission Controller - Warm Pool", func() {
 
 			By("Reconciling the mission")
 			reconciler := &MissionReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-				Recorder: record.NewFakeRecorder(100),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				Recorder:  record.NewFakeRecorder(100),
 				Assembler: &missionpkg.KnightAssembler{Client: k8sClient, Scheme: k8sClient.Scheme()},
 			}
 
@@ -1735,7 +1734,7 @@ var _ = Describe("Mission Controller - Warm Pool", func() {
 					Name:      rtName + "-warm-override",
 					Namespace: namespace,
 					Labels: map[string]string{
-						aiv1alpha1.LabelRoundTable: rtName,
+						aiv1alpha1.LabelRoundTable:      rtName,
 						aiv1alpha1.LabelWarmPool:        "true",
 						aiv1alpha1.LabelWarmPoolClaimed: "false",
 					},
@@ -1801,9 +1800,9 @@ var _ = Describe("Mission Controller - Warm Pool", func() {
 
 			By("Reconciling the mission")
 			reconciler := &MissionReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-				Recorder: record.NewFakeRecorder(100),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				Recorder:  record.NewFakeRecorder(100),
 				Assembler: &missionpkg.KnightAssembler{Client: k8sClient, Scheme: k8sClient.Scheme()},
 			}
 
@@ -1959,9 +1958,9 @@ var _ = Describe("Mission Controller - Generated Chains", func() {
 
 			By("Reconciling the mission")
 			reconciler := &MissionReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-				Recorder: record.NewFakeRecorder(100),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				Recorder:  record.NewFakeRecorder(100),
 				Assembler: &missionpkg.KnightAssembler{Client: k8sClient, Scheme: k8sClient.Scheme()},
 			}
 
@@ -1975,7 +1974,7 @@ var _ = Describe("Mission Controller - Generated Chains", func() {
 			By("Verifying the generated chain has roundTableRef")
 			generatedChainName := fmt.Sprintf("mission-%s-test-chain-template", missionName)
 			generatedChain := &aiv1alpha1.Chain{}
-			
+
 			Eventually(func() error {
 				return k8sClient.Get(ctx, types.NamespacedName{
 					Name:      generatedChainName,
@@ -1983,7 +1982,7 @@ var _ = Describe("Mission Controller - Generated Chains", func() {
 				}, generatedChain)
 			}, "5s", "500ms").Should(Succeed())
 
-			Expect(generatedChain.Spec.RoundTableRef).To(Equal(rtName), 
+			Expect(generatedChain.Spec.RoundTableRef).To(Equal(rtName),
 				"Generated chain should inherit roundTableRef from parent mission")
 		})
 
@@ -2027,8 +2026,8 @@ var _ = Describe("Mission Controller - Generated Chains", func() {
 					Name:      plannerChainName,
 					Namespace: namespace,
 					Labels: map[string]string{
-						aiv1alpha1.LabelMission:          missionName,
-						aiv1alpha1.LabelEphemeral:        "true",
+						aiv1alpha1.LabelMission:         missionName,
+						aiv1alpha1.LabelEphemeral:       "true",
 						"ai.roundtable.io/generated-by": "planner",
 					},
 				},

--- a/internal/controller/mission_controller_test_issue89.go
+++ b/internal/controller/mission_controller_test_issue89.go
@@ -43,19 +43,19 @@ func TestConflictErrorsCauseCleanRequeue(t *testing.T) {
 			TTL: 3600,
 		},
 	}
-	
+
 	// Mock client that returns conflict on status update
 	mockClient := &MockClient{
 		UpdateFunc: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 			return apierrors.NewConflict(schema.GroupResource{}, "test", nil)
 		},
 	}
-	
+
 	r := &MissionReconciler{Client: mockClient}
-	
+
 	// Execute
 	result, err := r.reconcilePending(ctx, mission)
-	
+
 	// Assert: Should requeue without error
 	assert.Nil(t, err)
 	assert.True(t, result.Requeue)
@@ -83,13 +83,13 @@ func TestMissionWaitsForAllChainsTerminal(t *testing.T) {
 			},
 		},
 	}
-	
+
 	// Mock reconcileMissionChains to return allComplete=true (2/3 complete)
 	// but the guard should catch the running chain
-	
+
 	r := &MissionReconciler{Client: mockClient}
 	result, err := r.reconcileActive(ctx, mission)
-	
+
 	// Assert: Mission should stay Active and requeue
 	assert.Nil(t, err)
 	assert.Equal(t, aiv1alpha1.MissionPhaseActive, mission.Status.Phase)
@@ -105,14 +105,14 @@ func TestChainNamingConsistency(t *testing.T) {
 			MetaMission: true,
 		},
 	}
-	
+
 	// Planner creates chain
 	planner := &mission.Planner{}
 	plannerChainName := fmt.Sprintf("mission-%s-%s", mission.Name, "investigation")
-	
+
 	// Mission controller expects chain
 	missionChainName := fmt.Sprintf("mission-%s-%s", mission.Name, "investigation")
-	
+
 	// Assert: Names match
 	assert.Equal(t, plannerChainName, missionChainName)
 }

--- a/internal/controller/mission_integration_test.go
+++ b/internal/controller/mission_integration_test.go
@@ -161,9 +161,9 @@ var _ = Describe("Mission Integration Tests", func() {
 
 			// Reconcile until phase transitions from Pending
 			r := &MissionReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-				Recorder: record.NewFakeRecorder(100),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				Recorder:  record.NewFakeRecorder(100),
 				Assembler: &missionpkg.KnightAssembler{Client: k8sClient, Scheme: k8sClient.Scheme()},
 			}
 
@@ -312,9 +312,9 @@ var _ = Describe("Mission Integration Tests", func() {
 			Expect(k8sClient.Create(ctx, mission)).To(Succeed())
 
 			r := &MissionReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-				Recorder: record.NewFakeRecorder(100),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				Recorder:  record.NewFakeRecorder(100),
 				Assembler: &missionpkg.KnightAssembler{Client: k8sClient, Scheme: k8sClient.Scheme()},
 			}
 
@@ -467,9 +467,9 @@ var _ = Describe("Mission Integration Tests", func() {
 			Expect(k8sClient.Create(ctx, mission)).To(Succeed())
 
 			r := &MissionReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-				Recorder: record.NewFakeRecorder(100),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				Recorder:  record.NewFakeRecorder(100),
 				Assembler: &missionpkg.KnightAssembler{Client: k8sClient, Scheme: k8sClient.Scheme()},
 			}
 
@@ -630,9 +630,9 @@ var _ = Describe("Mission Integration Tests", func() {
 			Expect(k8sClient.Create(ctx, mission)).To(Succeed())
 
 			r := &MissionReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-				Recorder: record.NewFakeRecorder(100),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				Recorder:  record.NewFakeRecorder(100),
 				Assembler: &missionpkg.KnightAssembler{Client: k8sClient, Scheme: k8sClient.Scheme()},
 			}
 
@@ -770,9 +770,9 @@ var _ = Describe("Mission Integration Tests", func() {
 			Expect(k8sClient.Create(ctx, mission)).To(Succeed())
 
 			r := &MissionReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-				Recorder: record.NewFakeRecorder(100),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				Recorder:  record.NewFakeRecorder(100),
 				Assembler: &missionpkg.KnightAssembler{Client: k8sClient, Scheme: k8sClient.Scheme()},
 			}
 

--- a/internal/controller/roundtable_controller.go
+++ b/internal/controller/roundtable_controller.go
@@ -514,8 +514,8 @@ func (r *RoundTableReconciler) listWarmPoolKnights(ctx context.Context, rt *aiv1
 		client.InNamespace(rt.Namespace),
 		client.MatchingLabels{
 			aiv1alpha1.LabelWarmPool:        "true",
-			aiv1alpha1.LabelWarmPoolClaimed:  claimedVal,
-			aiv1alpha1.LabelRoundTable:       rt.Name,
+			aiv1alpha1.LabelWarmPoolClaimed: claimedVal,
+			aiv1alpha1.LabelRoundTable:      rt.Name,
 		},
 	); err != nil {
 		return nil, fmt.Errorf("failed to list warm pool knights: %w", err)
@@ -571,7 +571,7 @@ func (r *RoundTableReconciler) createWarmKnight(ctx context.Context, rt *aiv1alp
 			Name:      name,
 			Namespace: rt.Namespace,
 			Labels: map[string]string{
-				aiv1alpha1.LabelWarmPool:       "true",
+				aiv1alpha1.LabelWarmPool:        "true",
 				aiv1alpha1.LabelWarmPoolClaimed: "false",
 				aiv1alpha1.LabelRoundTable:      rt.Name,
 			},

--- a/internal/knight/helpers.go
+++ b/internal/knight/helpers.go
@@ -24,8 +24,8 @@ import (
 	"sort"
 	"strings"
 
-	appsv1 "k8s.io/api/apps/v1"
 	aiv1alpha1 "github.com/dapperdivers/roundtable/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
 )
 
 // NixToolsHash computes a deterministic hash of the Nix tool list.
@@ -33,21 +33,21 @@ import (
 // Includes both knight.Spec.Tools.Nix and knight.Spec.NixPackages.
 func NixToolsHash(knight *aiv1alpha1.Knight) string {
 	var allTools []string
-	
+
 	// Collect from Tools.Nix
 	if knight.Spec.Tools != nil && len(knight.Spec.Tools.Nix) > 0 {
 		allTools = append(allTools, knight.Spec.Tools.Nix...)
 	}
-	
+
 	// Collect from NixPackages (legacy field)
 	if len(knight.Spec.NixPackages) > 0 {
 		allTools = append(allTools, knight.Spec.NixPackages...)
 	}
-	
+
 	if len(allTools) == 0 {
 		return ""
 	}
-	
+
 	// Sort for deterministic hash
 	sorted := make([]string, len(allTools))
 	copy(sorted, allTools)

--- a/internal/knight/pod_builder_test.go
+++ b/internal/knight/pod_builder_test.go
@@ -147,8 +147,8 @@ var _ = Describe("PodBuilder", func() {
 
 		It("adds writable subpaths correctly", func() {
 			knight.Spec.Vault = &aiv1alpha1.KnightVault{
-				ClaimName: "my-vault",
-				ReadOnly:  true,
+				ClaimName:     "my-vault",
+				ReadOnly:      true,
 				WritablePaths: []string{"logs/", "temp"},
 			}
 			builder.WithVault()

--- a/internal/mission/assembler.go
+++ b/internal/mission/assembler.go
@@ -273,7 +273,7 @@ func (a *KnightAssembler) claimWarmKnight(
 	if err := a.Client.List(ctx, knightList,
 		client.InNamespace(mission.Namespace),
 		client.MatchingLabels{
-			aiv1alpha1.LabelWarmPool:       "true",
+			aiv1alpha1.LabelWarmPool:        "true",
 			aiv1alpha1.LabelWarmPoolClaimed: "false",
 			aiv1alpha1.LabelRoundTable:      rt.Name,
 		},

--- a/internal/mission/mission_test.go
+++ b/internal/mission/mission_test.go
@@ -127,8 +127,8 @@ func TestParsePlannerOutput(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "JSON in markdown fence",
-			input: "```json\n" + `{"planVersion":"v1alpha1","metadata":{"objective":"fenced"}}` + "\n```",
+			name:    "JSON in markdown fence",
+			input:   "```json\n" + `{"planVersion":"v1alpha1","metadata":{"objective":"fenced"}}` + "\n```",
 			wantErr: false,
 			check: func(t *testing.T, po *PlannerOutput) {
 				if po.Metadata.Objective != "fenced" {
@@ -137,8 +137,8 @@ func TestParsePlannerOutput(t *testing.T) {
 			},
 		},
 		{
-			name: "minimal valid - empty arrays",
-			input: `{"planVersion":"v1alpha1","metadata":{"objective":"min"}}`,
+			name:    "minimal valid - empty arrays",
+			input:   `{"planVersion":"v1alpha1","metadata":{"objective":"min"}}`,
 			wantErr: false,
 			check: func(t *testing.T, po *PlannerOutput) {
 				if len(po.Chains) != 0 {

--- a/internal/mission/planner.go
+++ b/internal/mission/planner.go
@@ -13,8 +13,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	aiv1alpha1 "github.com/dapperdivers/roundtable/api/v1alpha1"
@@ -235,10 +235,10 @@ func (p *Planner) ReconcilePlanning(ctx context.Context, mission *aiv1alpha1.Mis
 
 	// Bug #85: Set PlanApplied condition to prevent duplicate applications on retry
 	meta.SetStatusCondition(&mission.Status.Conditions, metav1.Condition{
-		Type:    "PlanApplied",
-		Status:  metav1.ConditionTrue,
-		Reason:  "PlanningComplete",
-		Message: fmt.Sprintf("Generated %d chains, %d knights, %d skills", pr.ChainsGenerated, pr.KnightsGenerated, pr.SkillsGenerated),
+		Type:               "PlanApplied",
+		Status:             metav1.ConditionTrue,
+		Reason:             "PlanningComplete",
+		Message:            fmt.Sprintf("Generated %d chains, %d knights, %d skills", pr.ChainsGenerated, pr.KnightsGenerated, pr.SkillsGenerated),
 		ObservedGeneration: mission.Generation,
 	})
 
@@ -255,16 +255,16 @@ func (p *Planner) ReconcilePlanning(ctx context.Context, mission *aiv1alpha1.Mis
 	if err := p.Client.Update(ctx, mission); err != nil {
 		return ctrl.Result{}, err
 	}
-	
+
 	// Transition to Assembling phase with the PlanApplied condition in one update
 	mission.Status.Phase = aiv1alpha1.MissionPhaseAssembling
 	mission.Status.ObservedGeneration = mission.Generation
-	
+
 	if err := p.Client.Status().Update(ctx, mission); err != nil {
 		// If status update fails, return error for requeue with fresh object
 		return ctrl.Result{}, fmt.Errorf("failed to update mission status after plan application: %w", err)
 	}
-	
+
 	return ctrl.Result{}, nil
 }
 
@@ -312,7 +312,7 @@ func (p *Planner) ensurePlannerKnight(ctx context.Context, mission *aiv1alpha1.M
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve RoundTable: %w", err)
 		}
-		
+
 		// Check mission templates first (local override)
 		found := false
 		for _, template := range mission.Spec.KnightTemplates {
@@ -323,7 +323,7 @@ func (p *Planner) ensurePlannerKnight(ctx context.Context, mission *aiv1alpha1.M
 				break
 			}
 		}
-		
+
 		// Fall back to RoundTable templates
 		if !found {
 			templateSpec, ok := rt.Spec.KnightTemplates[planner.TemplateRef]
@@ -596,7 +596,7 @@ func (p *Planner) pollPlanningResult(ctx context.Context, mission *aiv1alpha1.Mi
 	}
 
 	resultsStream := plannerKnight.Spec.NATS.ResultsStream
-	
+
 	var subjectPrefix string
 	if len(plannerKnight.Spec.NATS.Subjects) > 0 {
 		parts := strings.SplitN(plannerKnight.Spec.NATS.Subjects[0], ".tasks.", 2)
@@ -604,7 +604,7 @@ func (p *Planner) pollPlanningResult(ctx context.Context, mission *aiv1alpha1.Mi
 			subjectPrefix = parts[0]
 		}
 	}
-	
+
 	if subjectPrefix == "" {
 		return nil, fmt.Errorf("cannot derive NATS subject prefix from planner knight %q subjects: %v",
 			plannerKnight.Name, plannerKnight.Spec.NATS.Subjects)
@@ -899,7 +899,7 @@ func (p *Planner) applyPlan(ctx context.Context, mission *aiv1alpha1.Mission, pl
 		// Build mapping of old names to new sanitized names
 		nameMap := make(map[string]string)
 		sanitizedSteps := make([]aiv1alpha1.ChainStep, len(pc.Steps))
-		
+
 		// Build a set of ephemeral knight names for knightRef prefixing
 		ephemeralKnights := make(map[string]bool)
 		for _, pk := range plan.Knights {
@@ -912,7 +912,7 @@ func (p *Planner) applyPlan(ctx context.Context, mission *aiv1alpha1.Mission, pl
 			oldName := step.Name
 			newName := sanitizeStepName(oldName)
 			nameMap[oldName] = newName
-			
+
 			sanitizedSteps[i] = step
 			sanitizedSteps[i].Name = newName
 
@@ -921,7 +921,7 @@ func (p *Planner) applyPlan(ctx context.Context, mission *aiv1alpha1.Mission, pl
 				sanitizedSteps[i].KnightRef = fmt.Sprintf("%s-%s", mission.Name, step.KnightRef)
 			}
 		}
-		
+
 		// Sanitize dependsOn references and task templates
 		for i := range sanitizedSteps {
 			// Sanitize dependsOn array
@@ -932,7 +932,7 @@ func (p *Planner) applyPlan(ctx context.Context, mission *aiv1alpha1.Mission, pl
 				}
 				sanitizedSteps[i].DependsOn = sanitizedDeps
 			}
-			
+
 			// Replace old hyphenated names in task templates with sanitized versions
 			task := sanitizedSteps[i].Task
 			for oldName, newName := range nameMap {
@@ -967,8 +967,8 @@ func (p *Planner) applyPlan(ctx context.Context, mission *aiv1alpha1.Mission, pl
 				Name:      chainName,
 				Namespace: mission.Namespace,
 				Labels: map[string]string{
-					aiv1alpha1.LabelMission:   mission.Name,
-					aiv1alpha1.LabelEphemeral: "true",
+					aiv1alpha1.LabelMission:         mission.Name,
+					aiv1alpha1.LabelEphemeral:       "true",
 					"ai.roundtable.io/generated-by": "planner",
 				},
 				OwnerReferences: []metav1.OwnerReference{

--- a/internal/mission/types.go
+++ b/internal/mission/types.go
@@ -21,22 +21,22 @@ type PlannerMetadata struct {
 }
 
 type PlannerChain struct {
-	Name        string                      `json:"name"`
-	Description string                      `json:"description,omitempty"`
-	Phase       string                      `json:"phase,omitempty"`
-	Steps       []aiv1alpha1.ChainStep      `json:"steps"`
-	Input       string                      `json:"input,omitempty"`
-	Timeout     *int32                      `json:"timeout,omitempty"`
+	Name        string                       `json:"name"`
+	Description string                       `json:"description,omitempty"`
+	Phase       string                       `json:"phase,omitempty"`
+	Steps       []aiv1alpha1.ChainStep       `json:"steps"`
+	Input       string                       `json:"input,omitempty"`
+	Timeout     *int32                       `json:"timeout,omitempty"`
 	RetryPolicy *aiv1alpha1.ChainRetryPolicy `json:"retryPolicy,omitempty"`
 }
 
 type PlannerKnight struct {
-	Name          string                             `json:"name"`
-	Role          string                             `json:"role,omitempty"`
-	Ephemeral     bool                               `json:"ephemeral"`
-	TemplateRef   string                             `json:"templateRef,omitempty"`
-	EphemeralSpec *aiv1alpha1.KnightSpec             `json:"ephemeralSpec,omitempty"`
-	SpecOverrides *aiv1alpha1.KnightSpecOverrides    `json:"specOverrides,omitempty"`
+	Name          string                          `json:"name"`
+	Role          string                          `json:"role,omitempty"`
+	Ephemeral     bool                            `json:"ephemeral"`
+	TemplateRef   string                          `json:"templateRef,omitempty"`
+	EphemeralSpec *aiv1alpha1.KnightSpec          `json:"ephemeralSpec,omitempty"`
+	SpecOverrides *aiv1alpha1.KnightSpecOverrides `json:"specOverrides,omitempty"`
 }
 
 type PlannerSkill struct {

--- a/internal/status/builder.go
+++ b/internal/status/builder.go
@@ -19,8 +19,8 @@ package status
 import (
 	"context"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	aiv1alpha1 "github.com/dapperdivers/roundtable/api/v1alpha1"

--- a/internal/util/dag_test.go
+++ b/internal/util/dag_test.go
@@ -137,6 +137,6 @@ func TestValidateDAG(t *testing.T) {
 
 // Helper function for substring check
 func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || 
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
 		(len(s) > 0 && (s[:len(substr)] == substr || contains(s[1:], substr))))
 }

--- a/pkg/nats/client_test.go
+++ b/pkg/nats/client_test.go
@@ -68,14 +68,14 @@ func TestConfigValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := NewClient(tt.config, logr.Discard())
-			
+
 			// Attempt to connect - expect failure for invalid configs
 			err := client.Connect()
-			
+
 			if tt.wantErr && err == nil {
 				t.Errorf("expected error for config with empty URL, got nil")
 			}
-			
+
 			if !tt.wantErr && tt.config.URL != "" && err != nil {
 				// It's OK to fail connection if NATS server not available
 				// We're just testing that config is accepted
@@ -114,7 +114,7 @@ func TestPublishWithNilConnection(t *testing.T) {
 		RetryOnFailedConnect: false,
 		MaxReconnects:        0,
 	}
-	
+
 	client := &JetStreamClient{
 		config: config,
 		log:    logr.Discard(),
@@ -138,7 +138,7 @@ func TestIsConnected(t *testing.T) {
 	config := Config{
 		URL: "nats://invalid.nonexistent.local:9999",
 	}
-	
+
 	client := &JetStreamClient{
 		config: config,
 		log:    logr.Discard(),
@@ -154,9 +154,9 @@ func TestCloseWithoutConnection(t *testing.T) {
 	config := Config{
 		URL: "nats://localhost:4222",
 	}
-	
+
 	client := NewClient(config, logr.Discard())
-	
+
 	err := client.Close()
 	if err != nil {
 		t.Errorf("expected no error when closing unconnected client, got %v", err)
@@ -655,7 +655,7 @@ func TestJSONPublishErrors(t *testing.T) {
 	config := Config{
 		URL: "nats://invalid.nonexistent.local:9999",
 	}
-	
+
 	client := &JetStreamClient{
 		config: config,
 		log:    logr.Discard(),


### PR DESCRIPTION
Foundation (2 of 3 repos) for replacing **25 per-knight 5Gi Nix PVCs (~125Gi allocated, ~2.2Gi each, near-identical)** with one RWX shared store: one writer (these build Jobs), many read-only readers (knights). Pairs with pi-knight #33 (the `nix-build.sh` builder script) and a dapper-cluster PVC manifest.

## How it works

When a PVC named `roundtable-nix-store` exists in the namespace, `reconcileNixBuildJob` creates a per-knight build Job that runs pi-knight's `/app/scripts/nix-build.sh` with the shared store mounted **read-write** and the knight's existing `flake.nix` ConfigMap at `/config`. The Job builds the flake and publishes `/nix/var/nix/profiles/knights/<name>`.

- **Gated on the nix-tools hash** and recorded in `status.nixToolsHash`, so an unchanged tool set never rebuilds. Jobs are named `<knight>-nixbuild-<hash>` (immutable Job specs → new hash, new Job) with `ttlSecondsAfterFinished` cleanup.
- **Inert until the shared PVC exists** — the operator can ship ahead of the PVC and activate automatically once GitOps creates it. Knights keep their per-pod Nix PVCs throughout, so this populates the shared store with zero disruption. A later PR flips knights to a read-only mount.

## Changes

- `internal/controller/knight_nixbuild.go` — `reconcileNixBuildJob` + `buildNixBuildJob`; wired into `Reconcile` (step 2b) and `Owns(&batchv1.Job{})`
- `status.nixToolsHash` field (CRD + chart CRD regenerated)
- `batch/jobs` RBAC (config/rbac/role.yaml + chart `rbac.yaml`)
- chart `0.9.0 → 0.10.0`
- `knight_nixbuild_test.go` — pure Job-shape test (RW `/nix`, scratch emptyDir off the store, lowercase `KNIGHT_NAME` profile key, config CM wiring) + envtest gating tests (no-op without PVC, Job created with PVC, hash-match short-circuit)

## Testing

`go build ./...`, `go vet`, and the full controller suite (`make test`) pass — **103/103 specs**. (`make test` exits non-zero only on a `covdata` toolchain glitch during the coverage merge, unrelated to these tests; `go test ./internal/controller` with envtest assets is green.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)