### PR TITLE
fix: run Nix build Job as 1000:1000 to match knights and pass policy

### DIFF
--- a/charts/roundtable-operator/Chart.yaml
+++ b/charts/roundtable-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: roundtable-operator
 description: Knights of the Round Table — A Kubernetes Operator for Multi-Agent AI Orchestration
 type: application
-version: 0.10.0
+version: 0.10.1
 appVersion: "1.0.0"
 keywords:
   - ai

--- a/internal/controller/knight_nixbuild.go
+++ b/internal/controller/knight_nixbuild.go
@@ -138,6 +138,16 @@ func (r *KnightReconciler) buildNixBuildJob(knight *aiv1alpha1.Knight, hash, job
 				ObjectMeta: metav1.ObjectMeta{Labels: labels},
 				Spec: corev1.PodSpec{
 					RestartPolicy: corev1.RestartPolicyNever,
+					// Match the knight pods (uid/gid 1000, fsGroup 1000) so the
+					// builder writes shared-store paths the read-only knights can
+					// read, and to satisfy non-root cluster policy.
+					AutomountServiceAccountToken: ptr.To(false),
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsUser:    ptr.To(int64(1000)),
+						RunAsGroup:   ptr.To(int64(1000)),
+						RunAsNonRoot: ptr.To(true),
+						FSGroup:      ptr.To(int64(1000)),
+					},
 					Containers: []corev1.Container{
 						{
 							Name:    "nixbuild",
@@ -149,6 +159,11 @@ func (r *KnightReconciler) buildNixBuildJob(knight *aiv1alpha1.Knight, hash, job
 								{Name: "KNIGHT_NAME", Value: knight.Name},
 								{Name: "FLAKE_FILE", Value: "/config/flake.nix"},
 								{Name: "TMPDIR", Value: "/scratch"},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+								SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{Name: "nix", MountPath: "/nix"},

--- a/internal/controller/knight_nixbuild_test.go
+++ b/internal/controller/knight_nixbuild_test.go
@@ -83,6 +83,13 @@ var _ = Describe("Knight Nix build Job", func() {
 			Expect(vols["nix"].PersistentVolumeClaim.ClaimName).To(Equal(sharedNixStorePVCName))
 			Expect(vols["config"].ConfigMap.Name).To(Equal("knight-galahad-config"))
 			Expect(vols["scratch"].EmptyDir).NotTo(BeNil())
+
+			// Runs as 1000:1000/fsGroup 1000 so shared-store files are readable
+			// by the read-only knight pods (which also run as 1000).
+			Expect(*pod.SecurityContext.RunAsUser).To(Equal(int64(1000)))
+			Expect(*pod.SecurityContext.FSGroup).To(Equal(int64(1000)))
+			Expect(*pod.SecurityContext.RunAsNonRoot).To(BeTrue())
+			Expect(*c.SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
 		})
 	})
 


### PR DESCRIPTION
Follow-up to #125. The per-knight Nix build Job set no securityContext, so it ran as **root** — it would write root-owned paths into the shared CephFS store while knight pods read it as uid 1000, and it tripped the cluster's non-root policy. Caught on deploy: the first build Jobs also StartError'd because the pinned pi-knight image predated `nix-build.sh` (fixed by bumping the image in GitOps), and the securityContext gap surfaced alongside it.

## Change

Run the build Job as **1000:1000 with fsGroup 1000**, matching the knight pods, so shared-store files are readable by the read-only knights. Plus standard hardening: `allowPrivilegeEscalation: false`, drop ALL caps, RuntimeDefault seccomp, no service-account token. Chart `0.10.0 → 0.10.1`.

## Testing

`go build`, controller suite green (envtest), with new assertions on the Job's pod/container securityContext.

🤖 Generated with [Claude Code](https://claude.com/claude-code)