### PR TITLE
fix: allowUnfree flake + centralized chart-driven pod security context

### DIFF
--- a/charts/roundtable-operator/Chart.yaml
+++ b/charts/roundtable-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: roundtable-operator
 description: Knights of the Round Table — A Kubernetes Operator for Multi-Agent AI Orchestration
 type: application
-version: 0.10.1
+version: 0.10.2
 appVersion: "1.0.0"
 keywords:
   - ai

--- a/charts/roundtable-operator/templates/deployment.yaml
+++ b/charts/roundtable-operator/templates/deployment.yaml
@@ -44,6 +44,16 @@ spec:
           env:
             - name: DEFAULT_KNIGHT_IMAGE
               value: "{{ .Values.images.piKnight.repository }}:{{ .Values.images.piKnight.tag }}"
+            # Pod security context applied to knight Deployments and Nix build
+            # Jobs alike (set once here, reused by the operator).
+            - name: KNIGHT_RUN_AS_USER
+              value: "{{ .Values.knightSecurity.runAsUser }}"
+            - name: KNIGHT_RUN_AS_GROUP
+              value: "{{ .Values.knightSecurity.runAsGroup }}"
+            - name: KNIGHT_FS_GROUP
+              value: "{{ .Values.knightSecurity.fsGroup }}"
+            - name: KNIGHT_FS_GROUP_CHANGE_POLICY
+              value: "{{ .Values.knightSecurity.fsGroupChangePolicy }}"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/charts/roundtable-operator/values.yaml
+++ b/charts/roundtable-operator/values.yaml
@@ -39,6 +39,16 @@ images:
     repository: ghcr.io/dapperdivers/roundtable-ui
     tag: latest
 
+# Pod-level security context for all knight-owned pods — knight Deployments
+# AND the shared Nix store build Jobs. Set once here; the operator applies it
+# everywhere. OnRootMismatch is important: it stops kubelet from recursively
+# chowning the (large) shared Nix store on every pod mount.
+knightSecurity:
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  fsGroupChangePolicy: OnRootMismatch
+
 # Dashboard (Round Table UI) — observability platform
 dashboard:
   enabled: true

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -40,6 +40,7 @@ import (
 
 	aiv1alpha1 "github.com/dapperdivers/roundtable/api/v1alpha1"
 	"github.com/dapperdivers/roundtable/internal/controller"
+	knightpkg "github.com/dapperdivers/roundtable/internal/knight"
 	"github.com/dapperdivers/roundtable/internal/mission"
 	natspkg "github.com/dapperdivers/roundtable/pkg/nats"
 	rtruntime "github.com/dapperdivers/roundtable/pkg/runtime"
@@ -203,11 +204,13 @@ func main() {
 	}()
 
 	defaultImage := os.Getenv("DEFAULT_KNIGHT_IMAGE")
+	knightSecurity := knightpkg.PodSecurityFromEnv()
 	knightReconciler := &controller.KnightReconciler{
-		Client:       mgr.GetClient(),
-		Scheme:       mgr.GetScheme(),
-		Recorder:     mgr.GetEventRecorderFor("knight-controller"),
-		DefaultImage: defaultImage,
+		Client:         mgr.GetClient(),
+		Scheme:         mgr.GetScheme(),
+		Recorder:       mgr.GetEventRecorderFor("knight-controller"),
+		DefaultImage:   defaultImage,
+		KnightSecurity: knightSecurity,
 	}
 
 	// Create runtime backends

--- a/internal/controller/knight_controller.go
+++ b/internal/controller/knight_controller.go
@@ -57,6 +57,11 @@ type KnightReconciler struct {
 	Recorder     record.EventRecorder
 	DefaultImage string // Default pi-knight image (set via DEFAULT_KNIGHT_IMAGE env var)
 
+	// KnightSecurity is the pod-level security context applied to both knight
+	// Deployments and Nix build Jobs. Chart-driven (KNIGHT_* env vars); zero
+	// value falls back to DefaultPodSecurity.
+	KnightSecurity knightpkg.PodSecurity
+
 	// RuntimeBackend abstracts the lifecycle of Knight runtime resources.
 	// When set, the controller delegates Deployment reconciliation and
 	// suspend/resume to this backend. When nil, falls back to the
@@ -621,6 +626,7 @@ func (r *KnightReconciler) BuildPodSpec(ctx context.Context, k *aiv1alpha1.Knigh
 	configMapName := fmt.Sprintf("knight-%s-config", k.Name)
 
 	builder := knightpkg.NewPodBuilder(k, r.DefaultImage).
+		WithSecurity(r.KnightSecurity).
 		WithReader(r.Client).
 		WithWorkspace().
 		WithConfig(configMapName).

--- a/internal/controller/knight_nixbuild.go
+++ b/internal/controller/knight_nixbuild.go
@@ -138,16 +138,12 @@ func (r *KnightReconciler) buildNixBuildJob(knight *aiv1alpha1.Knight, hash, job
 				ObjectMeta: metav1.ObjectMeta{Labels: labels},
 				Spec: corev1.PodSpec{
 					RestartPolicy: corev1.RestartPolicyNever,
-					// Match the knight pods (uid/gid 1000, fsGroup 1000) so the
-					// builder writes shared-store paths the read-only knights can
-					// read, and to satisfy non-root cluster policy.
+					// Shared with the knight pods (uid/gid/fsGroup + OnRootMismatch)
+					// so the builder writes shared-store paths the read-only
+					// knights can read, kubelet doesn't recursively chown the
+					// large store on every mount, and non-root policy is met.
 					AutomountServiceAccountToken: ptr.To(false),
-					SecurityContext: &corev1.PodSecurityContext{
-						RunAsUser:    ptr.To(int64(1000)),
-						RunAsGroup:   ptr.To(int64(1000)),
-						RunAsNonRoot: ptr.To(true),
-						FSGroup:      ptr.To(int64(1000)),
-					},
+					SecurityContext:              r.KnightSecurity.PodSecurityContext(),
 					Containers: []corev1.Container{
 						{
 							Name:    "nixbuild",

--- a/internal/controller/knight_nixbuild_test.go
+++ b/internal/controller/knight_nixbuild_test.go
@@ -89,6 +89,9 @@ var _ = Describe("Knight Nix build Job", func() {
 			Expect(*pod.SecurityContext.RunAsUser).To(Equal(int64(1000)))
 			Expect(*pod.SecurityContext.FSGroup).To(Equal(int64(1000)))
 			Expect(*pod.SecurityContext.RunAsNonRoot).To(BeTrue())
+			// OnRootMismatch — without it kubelet recursively chowns the whole
+			// shared store on every mount (the build-failure root cause).
+			Expect(*pod.SecurityContext.FSGroupChangePolicy).To(Equal(corev1.FSGroupChangeOnRootMismatch))
 			Expect(*c.SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
 		})
 	})

--- a/internal/knight/helpers.go
+++ b/internal/knight/helpers.go
@@ -66,7 +66,9 @@ func GenerateFlakeNix(knight *aiv1alpha1.Knight) string {
 	sb.WriteString("  outputs = { self, nixpkgs }:\n")
 	sb.WriteString("    let\n")
 	sb.WriteString("      system = \"x86_64-linux\";\n")
-	sb.WriteString("      pkgs = nixpkgs.legacyPackages.${system};\n")
+	// allowUnfree: many security/pentest tools (wpscan, burpsuite, …) are
+	// unfree and otherwise fail the build with an allowUnfree error.
+	sb.WriteString("      pkgs = import nixpkgs { inherit system; config.allowUnfree = true; };\n")
 	sb.WriteString("    in {\n")
 	sb.WriteString("      packages.${system}.default = pkgs.buildEnv {\n")
 	sb.WriteString("        name = \"knight-" + knight.Name + "-tools\";\n")

--- a/internal/knight/pod_builder.go
+++ b/internal/knight/pod_builder.go
@@ -40,6 +40,7 @@ type PodBuilder struct {
 	sidecars   []corev1.Container
 	env        []corev1.EnvVar
 	defaultImg string
+	security   PodSecurity
 	reader     client.Reader
 }
 
@@ -52,7 +53,15 @@ func NewPodBuilder(k *aiv1alpha1.Knight, defaultImage string) *PodBuilder {
 		sidecars:   []corev1.Container{},
 		env:        []corev1.EnvVar{},
 		defaultImg: defaultImage,
+		security:   DefaultPodSecurity(),
 	}
+}
+
+// WithSecurity sets the pod-level security context (shared with the Nix build
+// Jobs). Defaults to DefaultPodSecurity when not called.
+func (b *PodBuilder) WithSecurity(s PodSecurity) *PodBuilder {
+	b.security = s.OrDefault()
+	return b
 }
 
 // WithReader sets the client reader for looking up resources.
@@ -489,21 +498,11 @@ func (b *PodBuilder) Build(ctx context.Context) corev1.PodSpec {
 	containers := []corev1.Container{knightContainer}
 	containers = append(containers, b.sidecars...)
 
-	// Pod security context
-	fsGroup := int64(1000)
-	runAsUser := int64(1000)
-	runAsGroup := int64(1000)
-
 	return corev1.PodSpec{
-		Containers:         containers,
-		Volumes:            b.volumes,
-		EnableServiceLinks: util.BoolPtr(false),
-		SecurityContext: &corev1.PodSecurityContext{
-			RunAsUser:           &runAsUser,
-			RunAsGroup:          &runAsGroup,
-			FSGroup:             &fsGroup,
-			FSGroupChangePolicy: util.FSGroupChangePolicyPtr(corev1.FSGroupChangeOnRootMismatch),
-		},
+		Containers:                   containers,
+		Volumes:                      b.volumes,
+		EnableServiceLinks:           util.BoolPtr(false),
+		SecurityContext:              b.security.PodSecurityContext(),
 		ServiceAccountName:           b.knight.Spec.ServiceAccountName,
 		AutomountServiceAccountToken: util.BoolPtr(true),
 	}

--- a/internal/knight/security.go
+++ b/internal/knight/security.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2026 dapperdivers.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package knight
+
+import (
+	"os"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/dapperdivers/roundtable/internal/util"
+)
+
+// PodSecurity is the single source of truth for the pod-level security context
+// applied to every knight-owned pod — both knight Deployments and the Nix
+// build Jobs. The chart sets these once (operator env vars) and the operator
+// reuses them everywhere, so the knight pods and the shared-store builder
+// always agree (notably on fsGroup/FSGroupChangePolicy, which the read-only
+// shared Nix store depends on).
+type PodSecurity struct {
+	RunAsUser           int64
+	RunAsGroup          int64
+	FSGroup             int64
+	FSGroupChangePolicy corev1.PodFSGroupChangePolicy
+}
+
+// DefaultPodSecurity is the built-in default: uid/gid/fsGroup 1000 with
+// OnRootMismatch so kubelet does not recursively chown the (large) shared Nix
+// store on every mount.
+func DefaultPodSecurity() PodSecurity {
+	return PodSecurity{
+		RunAsUser:           1000,
+		RunAsGroup:          1000,
+		FSGroup:             1000,
+		FSGroupChangePolicy: corev1.FSGroupChangeOnRootMismatch,
+	}
+}
+
+// PodSecurityFromEnv reads chart-provided overrides, falling back to defaults:
+//
+//	KNIGHT_RUN_AS_USER, KNIGHT_RUN_AS_GROUP, KNIGHT_FS_GROUP (ints)
+//	KNIGHT_FS_GROUP_CHANGE_POLICY (Always | OnRootMismatch)
+func PodSecurityFromEnv() PodSecurity {
+	s := DefaultPodSecurity()
+	if v, err := strconv.ParseInt(os.Getenv("KNIGHT_RUN_AS_USER"), 10, 64); err == nil && v > 0 {
+		s.RunAsUser = v
+	}
+	if v, err := strconv.ParseInt(os.Getenv("KNIGHT_RUN_AS_GROUP"), 10, 64); err == nil && v > 0 {
+		s.RunAsGroup = v
+	}
+	if v, err := strconv.ParseInt(os.Getenv("KNIGHT_FS_GROUP"), 10, 64); err == nil && v > 0 {
+		s.FSGroup = v
+	}
+	if v := os.Getenv("KNIGHT_FS_GROUP_CHANGE_POLICY"); v != "" {
+		s.FSGroupChangePolicy = corev1.PodFSGroupChangePolicy(v)
+	}
+	return s
+}
+
+// OrDefault returns DefaultPodSecurity when the receiver is the zero value, so
+// callers that forget to set it never accidentally run pods as root (uid 0).
+func (s PodSecurity) OrDefault() PodSecurity {
+	if s.RunAsUser == 0 && s.RunAsGroup == 0 && s.FSGroup == 0 && s.FSGroupChangePolicy == "" {
+		return DefaultPodSecurity()
+	}
+	return s
+}
+
+// PodSecurityContext renders the pod-level security context.
+func (s PodSecurity) PodSecurityContext() *corev1.PodSecurityContext {
+	s = s.OrDefault()
+	runAsUser := s.RunAsUser
+	runAsGroup := s.RunAsGroup
+	fsGroup := s.FSGroup
+	return &corev1.PodSecurityContext{
+		RunAsUser:           &runAsUser,
+		RunAsGroup:          &runAsGroup,
+		RunAsNonRoot:        util.BoolPtr(runAsUser != 0),
+		FSGroup:             &fsGroup,
+		FSGroupChangePolicy: util.FSGroupChangePolicyPtr(s.FSGroupChangePolicy),
+	}
+}

--- a/internal/knight/security_test.go
+++ b/internal/knight/security_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 dapperdivers.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package knight
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestDefaultPodSecurityContext(t *testing.T) {
+	sc := DefaultPodSecurity().PodSecurityContext()
+	if *sc.RunAsUser != 1000 || *sc.RunAsGroup != 1000 || *sc.FSGroup != 1000 {
+		t.Errorf("expected 1000/1000/1000, got %d/%d/%d", *sc.RunAsUser, *sc.RunAsGroup, *sc.FSGroup)
+	}
+	if !*sc.RunAsNonRoot {
+		t.Error("expected RunAsNonRoot=true")
+	}
+	if *sc.FSGroupChangePolicy != corev1.FSGroupChangeOnRootMismatch {
+		t.Errorf("expected OnRootMismatch, got %s", *sc.FSGroupChangePolicy)
+	}
+}
+
+func TestPodSecurityOrDefault(t *testing.T) {
+	// Zero value must not produce a root (uid 0) pod.
+	sc := (PodSecurity{}).PodSecurityContext()
+	if *sc.RunAsUser != 1000 {
+		t.Errorf("zero value should default to 1000, got %d", *sc.RunAsUser)
+	}
+	if !*sc.RunAsNonRoot {
+		t.Error("zero value should still be non-root")
+	}
+
+	// Explicit values are preserved.
+	custom := PodSecurity{RunAsUser: 2000, RunAsGroup: 2000, FSGroup: 3000, FSGroupChangePolicy: corev1.FSGroupChangeAlways}
+	if custom.OrDefault().RunAsUser != 2000 || custom.OrDefault().FSGroup != 3000 {
+		t.Error("explicit values should be preserved by OrDefault")
+	}
+}
+
+func TestPodSecurityFromEnv(t *testing.T) {
+	t.Setenv("KNIGHT_RUN_AS_USER", "2000")
+	t.Setenv("KNIGHT_FS_GROUP", "3000")
+	t.Setenv("KNIGHT_FS_GROUP_CHANGE_POLICY", "Always")
+	s := PodSecurityFromEnv()
+	if s.RunAsUser != 2000 {
+		t.Errorf("expected RunAsUser 2000, got %d", s.RunAsUser)
+	}
+	if s.RunAsGroup != 1000 {
+		t.Errorf("unset RunAsGroup should default to 1000, got %d", s.RunAsGroup)
+	}
+	if s.FSGroup != 3000 {
+		t.Errorf("expected FSGroup 3000, got %d", s.FSGroup)
+	}
+	if s.FSGroupChangePolicy != corev1.FSGroupChangeAlways {
+		t.Errorf("expected Always, got %s", s.FSGroupChangePolicy)
+	}
+}


### PR DESCRIPTION
Fixes the two deploy-blockers that surfaced once the shared-store build Jobs ran for real, plus centralizes the pod security context as requested (set once in the chart, reused everywhere).

## 1. `allowUnfree` — the dominant build failure

`GenerateFlakeNix` now imports nixpkgs with `config.allowUnfree = true`. Security/pentest knights ship unfree tools (agravain's `wpscan`, etc.); the build Job failed hard with `package is unfree`. On the old per-pod path this same build failed **silently** (entrypoint Phase 3 was non-fatal), so those tools were quietly missing all along — the shared builder just made it visible by failing loudly.

## 2. Centralized pod security context (Derek's ask)

The `1000:1000` + `fsGroup` + `FSGroupChangePolicy` context was **hardcoded in two places** — knight pods (`pod_builder.go`) and build Jobs (`knight_nixbuild.go`) — and the build Job was **missing `FSGroupChangePolicy: OnRootMismatch`**. Without it, kubelet recursively `chown`ed the entire shared store (366k+ files) on every pod mount — 20+ min stalls, racing across 25 pods (`VolumePermissionChangeInProgress` in the events).

New `internal/knight/security.go` is the single source of truth:
- `PodSecurity` + `DefaultPodSecurity` + `PodSecurityFromEnv` + `OrDefault` (zero value → non-root 1000, so it can never accidentally run as root)
- Both knight pods (`WithSecurity`) and build Jobs (`r.KnightSecurity`) consume it
- Chart sets it once via `values.knightSecurity` → `KNIGHT_*` env vars on the operator deployment

Chart `0.10.1 → 0.10.2`.

## Testing

`go build`, `internal/knight` units (new `security_test.go`), and the controller envtest suite all pass; the build-Job test now asserts `OnRootMismatch`. `helm lint` + `helm template` confirm the env vars render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)