### PR TITLE
fix: run nix-build Job as root so source builds work

### DIFF
--- a/charts/roundtable-operator/Chart.yaml
+++ b/charts/roundtable-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: roundtable-operator
 description: Knights of the Round Table — A Kubernetes Operator for Multi-Agent AI Orchestration
 type: application
-version: 0.10.3
+version: 0.10.4
 appVersion: "1.0.0"
 keywords:
   - ai

--- a/internal/controller/knight_nixbuild.go
+++ b/internal/controller/knight_nixbuild.go
@@ -138,12 +138,21 @@ func (r *KnightReconciler) buildNixBuildJob(knight *aiv1alpha1.Knight, hash, job
 				ObjectMeta: metav1.ObjectMeta{Labels: labels},
 				Spec: corev1.PodSpec{
 					RestartPolicy: corev1.RestartPolicyNever,
-					// Shared with the knight pods (uid/gid/fsGroup + OnRootMismatch)
-					// so the builder writes shared-store paths the read-only
-					// knights can read, kubelet doesn't recursively chown the
-					// large store on every mount, and non-root policy is met.
+					// The builder runs as ROOT — deliberately diverging from the
+					// non-root knight pods. Nix is designed to build as root (the
+					// nix-daemon's whole job); building source derivations
+					// unprivileged with sandbox=false fails on permission ops
+					// (e.g. Ruby gem unpackPhase: "chmod: Operation not
+					// permitted"). This pod is ephemeral and isolated. The shared
+					// store stays readable by the uid-1000 knights because nix
+					// store paths are world-readable (0555). No fsGroup: root
+					// accesses the store directly, which also avoids a recursive
+					// chown of the large store on mount.
 					AutomountServiceAccountToken: ptr.To(false),
-					SecurityContext:              r.KnightSecurity.PodSecurityContext(),
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsUser:  ptr.To(int64(0)),
+						RunAsGroup: ptr.To(int64(0)),
+					},
 					Containers: []corev1.Container{
 						{
 							Name:    "nixbuild",
@@ -156,9 +165,11 @@ func (r *KnightReconciler) buildNixBuildJob(knight *aiv1alpha1.Knight, hash, job
 								{Name: "FLAKE_FILE", Value: "/config/flake.nix"},
 								{Name: "TMPDIR", Value: "/scratch"},
 							},
+							// Default capability set (no Drop ALL) so source builds
+							// can chown/chmod/setuid as Nix expects.
 							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: ptr.To(false),
-								Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+								AllowPrivilegeEscalation: ptr.To(true),
+								RunAsNonRoot:             ptr.To(false),
 								SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 							},
 							VolumeMounts: []corev1.VolumeMount{

--- a/internal/controller/knight_nixbuild_test.go
+++ b/internal/controller/knight_nixbuild_test.go
@@ -86,13 +86,13 @@ var _ = Describe("Knight Nix build Job", func() {
 
 			// Runs as 1000:1000/fsGroup 1000 so shared-store files are readable
 			// by the read-only knight pods (which also run as 1000).
-			Expect(*pod.SecurityContext.RunAsUser).To(Equal(int64(1000)))
-			Expect(*pod.SecurityContext.FSGroup).To(Equal(int64(1000)))
-			Expect(*pod.SecurityContext.RunAsNonRoot).To(BeTrue())
-			// OnRootMismatch — without it kubelet recursively chowns the whole
-			// shared store on every mount (the build-failure root cause).
-			Expect(*pod.SecurityContext.FSGroupChangePolicy).To(Equal(corev1.FSGroupChangeOnRootMismatch))
-			Expect(*c.SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
+			// The builder runs as root (Nix needs privilege for source builds);
+			// no fsGroup so it doesn't recursively chown the large shared store.
+			Expect(*pod.SecurityContext.RunAsUser).To(Equal(int64(0)))
+			Expect(pod.SecurityContext.FSGroup).To(BeNil())
+			Expect(*c.SecurityContext.RunAsNonRoot).To(BeFalse())
+			// Default capabilities (no Drop ALL) so source builds can chmod/chown.
+			Expect(c.SecurityContext.Capabilities).To(BeNil())
 		})
 	})
 


### PR DESCRIPTION
The 25th knight (agravain) wouldn't build: its `wpscan` pulls a Ruby gem (`ethon`) **not in the binary cache**, so Nix builds it from source — and the build failed with `chmod: changing permissions of 'source': Operation not permitted`. The other 24 knights only hit `cache.nixos.org` (no source build), so they were unaffected.

## Root cause

Nix is designed to build **as root** (that's the nix-daemon's entire purpose). Our build Job ran unprivileged (uid 1000, all caps dropped) with `sandbox = false` — fine for cache hits, but real source builds need privileged filesystem ops (`chmod`/`chown` in `unpackPhase`).

## Fix

Run the **ephemeral build Job as root** with the default capability set — deliberately diverging from the non-root (1000) knight pods. Builds need privilege; runtime knights don't. Safe because:
- The pod is ephemeral and isolated (one-shot Job).
- The shared store stays readable by the uid-1000 knights — nix store paths are world-readable (`0555`).
- No `fsGroup`: root accesses the store directly via uid 0, which also avoids the recursive chown of the (large) store on mount.

Kyverno will flag the build pod as root (audit-only here) — the one legitimate place the build-Job security context differs from the hardened knight context. Chart `0.10.3 → 0.10.4`.

## Testing

`go build`, `go vet`, controller envtest suite green (build-Job test updated: root uid, nil fsGroup, default caps). Post-deploy: agravain's `wpscan`/`ethon` builds and it reaches 25/25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)