### PR TITLE
feat: dispatch Nix builds to the persistent daemon builder via work queue

### DIFF
--- a/charts/roundtable-operator/Chart.yaml
+++ b/charts/roundtable-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: roundtable-operator
 description: Knights of the Round Table — A Kubernetes Operator for Multi-Agent AI Orchestration
 type: application
-version: 0.10.4
+version: 0.11.0
 appVersion: "1.0.0"
 keywords:
   - ai

--- a/charts/roundtable-operator/templates/deployment.yaml
+++ b/charts/roundtable-operator/templates/deployment.yaml
@@ -57,6 +57,12 @@ spec:
             # Pinned nixpkgs ref for reproducible knight tool builds.
             - name: KNIGHT_NIXPKGS_REF
               value: "{{ .Values.nixpkgs.ref }}"
+            {{- if and .Values.nixBuilder.enabled .Values.nixBuilder.mountQueue }}
+            # Presence of /queue switches the operator to queue-backed dispatch
+            # (the nix-daemon builder) instead of per-knight build Jobs.
+            - name: BUILD_QUEUE_DIR
+              value: /queue
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:
@@ -66,3 +72,14 @@ spec:
             capabilities:
               drop:
                 - ALL
+          {{- if and .Values.nixBuilder.enabled .Values.nixBuilder.mountQueue }}
+          volumeMounts:
+            - name: build-queue
+              mountPath: /queue
+          {{- end }}
+      {{- if and .Values.nixBuilder.enabled .Values.nixBuilder.mountQueue }}
+      volumes:
+        - name: build-queue
+          persistentVolumeClaim:
+            claimName: {{ .Values.nixBuilder.queueClaimName }}
+      {{- end }}

--- a/charts/roundtable-operator/templates/nix-builder.yaml
+++ b/charts/roundtable-operator/templates/nix-builder.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.nixBuilder.enabled }}
+---
+# Persistent shared-store builder. Single replica, root, the SOLE writer to the
+# shared Nix store: it runs a nix-daemon and processes the operator's build
+# requests off the work-queue PVC (see pi-knight scripts/nix-builder.sh). Strategy
+# Recreate guarantees there are never two writers across a rollout.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "roundtable-operator.fullname" . }}-nix-builder
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "roundtable-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: nix-builder
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "roundtable-operator.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: nix-builder
+  template:
+    metadata:
+      labels:
+        {{- include "roundtable-operator.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: nix-builder
+    spec:
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 120
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      # Root, NO fsGroup: the builder writes the store directly (Nix is built to
+      # build as root), and fsGroup would force a recursive chown of the large
+      # store on every mount. Store paths are world-readable (0555) so uid-1000
+      # knights still read the published profiles.
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+      containers:
+        - name: nix-builder
+          image: "{{ .Values.nixBuilder.image.repository | default .Values.images.piKnight.repository }}:{{ .Values.nixBuilder.image.tag | default .Values.images.piKnight.tag }}"
+          imagePullPolicy: {{ .Values.nixBuilder.image.pullPolicy | default "Always" }}
+          command: ["/app/scripts/nix-builder.sh"]
+          env:
+            - name: BUILD_QUEUE_DIR
+              value: /queue
+            - name: NIX_BUILD_CONCURRENCY
+              value: "{{ .Values.nixBuilder.concurrency }}"
+            - name: TMPDIR
+              value: /scratch
+          resources:
+            {{- toYaml .Values.nixBuilder.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: true
+            runAsNonRoot: false
+            readOnlyRootFilesystem: false
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: nix
+              mountPath: /nix
+            - name: queue
+              mountPath: /queue
+            - name: scratch
+              mountPath: /scratch
+      volumes:
+        - name: nix
+          persistentVolumeClaim:
+            claimName: {{ .Values.nixBuilder.storeClaimName }}
+        - name: queue
+          persistentVolumeClaim:
+            claimName: {{ .Values.nixBuilder.queueClaimName }}
+        - name: scratch
+          emptyDir:
+            sizeLimit: {{ .Values.nixBuilder.scratchSizeLimit }}
+{{- end }}

--- a/charts/roundtable-operator/values.yaml
+++ b/charts/roundtable-operator/values.yaml
@@ -55,6 +55,33 @@ knightSecurity:
 nixpkgs:
   ref: "9ae611a455b90cf061d8f332b977e387bda8e1ca" # nixos-unstable @ 2026-06-10
 
+# Persistent shared-store builder (the nix-daemon builder). When enabled, a
+# single-replica root Deployment owns the shared Nix store read-write, runs a
+# nix-daemon, and builds knight tools that the operator dispatches through an
+# RWX work-queue PVC — replacing the per-knight build Jobs + global store lock.
+# The operator auto-switches to queue dispatch whenever the queue PVC is mounted
+# into it (mountQueue, below); otherwise it falls back to the legacy build Jobs.
+nixBuilder:
+  enabled: false
+  # Mount the work-queue PVC into the operator so it dispatches via the queue.
+  # Keep in lockstep with enabled; split out only to stage a rollout if needed.
+  mountQueue: true
+  image:
+    # Defaults to images.piKnight when repository/tag are empty.
+    repository: ""
+    tag: ""
+    pullPolicy: Always
+  storeClaimName: roundtable-nix-store        # RWX; mounted read-write (sole writer)
+  queueClaimName: roundtable-nix-buildqueue   # RWX; operator<->builder coordination
+  concurrency: 6                              # concurrent `nix build` clients
+  scratchSizeLimit: 10Gi                      # emptyDir for build scratch (off the store)
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      memory: 4Gi
+
 # Dashboard (Round Table UI) — observability platform
 dashboard:
   enabled: true

--- a/internal/controller/knight_controller.go
+++ b/internal/controller/knight_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -161,10 +162,16 @@ func (r *KnightReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		log.Error(err, "Failed to reconcile PVC")
 	}
 
-	// 2b. Nix build Job (shared store) — no-op unless the shared store exists
-	if err := r.reconcileNixBuildJob(ctx, knight); err != nil {
+	// 2b. Nix build (shared store) — queue-backed nix-daemon builder, or the
+	//     legacy per-knight Job when the queue PVC is not mounted. No-op unless
+	//     a shared store / queue is available. Returns a poll interval while a
+	//     build is pending (queue results are files, not watched objects).
+	var nixRequeue time.Duration
+	if d, err := r.reconcileNixBuild(ctx, knight); err != nil {
 		reconcileErr = err
-		log.Error(err, "Failed to reconcile Nix build Job")
+		log.Error(err, "Failed to reconcile Nix build")
+	} else {
+		nixRequeue = d
 	}
 
 	// 3. Runtime (Deployment or Sandbox, depending on knight.Spec.Runtime)
@@ -188,6 +195,10 @@ func (r *KnightReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	if reconcileErr != nil {
 		return ctrl.Result{RequeueAfter: RequeueSlow}, reconcileErr
+	}
+
+	if nixRequeue > 0 {
+		return ctrl.Result{RequeueAfter: nixRequeue}, nil
 	}
 
 	return ctrl.Result{}, nil

--- a/internal/controller/knight_nixqueue.go
+++ b/internal/controller/knight_nixqueue.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2026 dapperdivers.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	aiv1alpha1 "github.com/dapperdivers/roundtable/api/v1alpha1"
+	knightpkg "github.com/dapperdivers/roundtable/internal/knight"
+)
+
+// buildQueueDir returns the mount path of the RWX build-queue PVC the operator
+// shares with the roundtable-nix-builder Deployment. When this directory exists
+// the operator dispatches Nix builds through the queue (the persistent
+// nix-daemon builder); when it is absent it falls back to the legacy per-knight
+// build Job. Overridable via BUILD_QUEUE_DIR for tests.
+func buildQueueDir() string {
+	if d := os.Getenv("BUILD_QUEUE_DIR"); d != "" {
+		return d
+	}
+	return "/queue"
+}
+
+// reconcileNixBuild ensures the knight's Nix tools are built into the shared
+// store. It prefers the queue-backed nix-daemon builder and falls back to the
+// legacy build Job when the queue PVC is not mounted. It returns a non-zero
+// requeue interval while a build is pending so the operator polls for the
+// result — queue results are plain files, not watched Kubernetes objects.
+func (r *KnightReconciler) reconcileNixBuild(ctx context.Context, knight *aiv1alpha1.Knight) (time.Duration, error) {
+	queue := buildQueueDir()
+	if _, err := os.Stat(queue); err != nil {
+		// Queue not mounted — legacy Job path (requeue driven by owner watch).
+		return 0, r.reconcileNixBuildJob(ctx, knight)
+	}
+	return r.reconcileNixBuildQueue(ctx, knight, queue)
+}
+
+// reconcileNixBuildQueue drives a build through the file-based work queue. The
+// queue protocol (keyed by "<knight>__<toolsHash>") is documented in
+// pi-knight's scripts/nix-builder.sh.
+func (r *KnightReconciler) reconcileNixBuildQueue(ctx context.Context, knight *aiv1alpha1.Knight, queue string) (time.Duration, error) {
+	log := logf.FromContext(ctx)
+
+	// GenerateFlakeNix renders from Spec.Tools.Nix; gate on the same field so a
+	// legacy NixPackages-only knight (which it can't render) takes the Job path.
+	if knight.Spec.Tools == nil || len(knight.Spec.Tools.Nix) == 0 {
+		return 0, nil
+	}
+
+	currentHash := knightpkg.NixToolsHash(knight)
+	if knight.Status.NixToolsHash == currentHash {
+		return 0, nil // already published
+	}
+
+	key := knight.Name + "__" + currentHash
+	reqDir := filepath.Join(queue, "requests", key)
+	okPath := filepath.Join(queue, "results", key+".ok")
+	errPath := filepath.Join(queue, "results", key+".err")
+
+	// Builder published a result?
+	if _, err := os.Stat(okPath); err == nil {
+		knight.Status.NixToolsHash = currentHash // persisted by updateStatus
+		r.Recorder.Eventf(knight, corev1.EventTypeNormal, "NixBuildComplete",
+			"Nix tools (hash %s) published to shared store", currentHash)
+		_ = os.RemoveAll(reqDir) // best-effort cleanup of the consumed request
+		_ = os.Remove(okPath)
+		_ = os.Remove(errPath)
+		r.pruneStaleBuildRequests(knight.Name, currentHash, queue)
+		return 0, nil
+	}
+
+	if _, err := os.Stat(errPath); err == nil {
+		// Surface the failure, but don't auto-loop on a genuinely broken flake.
+		// Deleting the .err marker (or changing the tool set) re-arms the build.
+		r.Recorder.Eventf(knight, corev1.EventTypeWarning, "NixBuildFailed",
+			"Nix build for hash %s failed; delete results/%s.err to retry", currentHash, key)
+		return RequeueVerySlow, nil
+	}
+
+	// No result yet — ensure exactly one ready request exists for this hash.
+	if _, err := os.Stat(filepath.Join(reqDir, "ready")); err == nil {
+		return RequeueSlow, nil // in flight
+	}
+
+	if err := writeBuildRequest(reqDir, knightpkg.GenerateFlakeNix(knight)); err != nil {
+		return 0, fmt.Errorf("write nix build request: %w", err)
+	}
+	r.pruneStaleBuildRequests(knight.Name, currentHash, queue)
+	log.Info("Nix build requested via queue", "knight", knight.Name, "toolsHash", currentHash)
+	r.Recorder.Eventf(knight, corev1.EventTypeNormal, "NixBuildRequested",
+		"Requested Nix tools build (hash %s) from shared builder", currentHash)
+	return RequeueSlow, nil
+}
+
+// writeBuildRequest writes flake.nix and then the ready marker last, so the
+// builder never observes a partially written request.
+func writeBuildRequest(reqDir, flake string) error {
+	if err := os.MkdirAll(reqDir, 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(reqDir, "flake.nix"), []byte(flake), 0o644); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(reqDir, "ready"), nil, 0o644)
+}
+
+// pruneStaleBuildRequests removes request dirs and result markers belonging to
+// this knight whose hash differs from keepHash (superseded tool sets), keeping
+// the queue from accumulating cruft as tools change mid-reconcile.
+func (r *KnightReconciler) pruneStaleBuildRequests(knightName, keepHash, queue string) {
+	prefix := knightName + "__"
+	keepKey := knightName + "__" + keepHash
+
+	if entries, err := os.ReadDir(filepath.Join(queue, "requests")); err == nil {
+		for _, e := range entries {
+			if strings.HasPrefix(e.Name(), prefix) && e.Name() != keepKey {
+				_ = os.RemoveAll(filepath.Join(queue, "requests", e.Name()))
+			}
+		}
+	}
+	if entries, err := os.ReadDir(filepath.Join(queue, "results")); err == nil {
+		for _, e := range entries {
+			base := strings.TrimSuffix(strings.TrimSuffix(e.Name(), ".ok"), ".err")
+			if strings.HasPrefix(base, prefix) && base != keepKey {
+				_ = os.Remove(filepath.Join(queue, "results", e.Name()))
+			}
+		}
+	}
+}

--- a/internal/controller/knight_nixqueue_test.go
+++ b/internal/controller/knight_nixqueue_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2026 dapperdivers.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+
+	aiv1alpha1 "github.com/dapperdivers/roundtable/api/v1alpha1"
+	knightpkg "github.com/dapperdivers/roundtable/internal/knight"
+)
+
+func nixQueueKnight() *aiv1alpha1.Knight {
+	return &aiv1alpha1.Knight{
+		ObjectMeta: metav1.ObjectMeta{Name: "agravain", Namespace: "roundtable"},
+		Spec: aiv1alpha1.KnightSpec{
+			Tools: &aiv1alpha1.KnightTools{Nix: []string{"nmap", "curl"}},
+		},
+	}
+}
+
+// TestReconcileNixBuildQueue_Lifecycle walks a build through the file queue:
+// first reconcile writes a ready request, then the builder's .ok result is
+// consumed (status set, request + result cleaned up).
+func TestReconcileNixBuildQueue_Lifecycle(t *testing.T) {
+	queue := t.TempDir()
+	r := &KnightReconciler{Recorder: record.NewFakeRecorder(100)}
+	knight := nixQueueKnight()
+	hash := knightpkg.NixToolsHash(knight)
+	key := knight.Name + "__" + hash
+
+	// 1. No request yet → writes flake + ready, asks to requeue.
+	d, err := r.reconcileNixBuildQueue(context.Background(), knight, queue)
+	if err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	if d <= 0 {
+		t.Fatalf("expected a poll requeue while pending, got %v", d)
+	}
+	flake := filepath.Join(queue, "requests", key, "flake.nix")
+	if b, err := os.ReadFile(flake); err != nil {
+		t.Fatalf("flake.nix not written: %v", err)
+	} else if len(b) == 0 {
+		t.Fatal("flake.nix is empty")
+	}
+	if _, err := os.Stat(filepath.Join(queue, "requests", key, "ready")); err != nil {
+		t.Fatalf("ready marker not written: %v", err)
+	}
+
+	// 2. Reconcile again while pending → still requeues, no duplicate work.
+	if _, err := r.reconcileNixBuildQueue(context.Background(), knight, queue); err != nil {
+		t.Fatalf("pending reconcile: %v", err)
+	}
+
+	// 3. Builder publishes a success result (the builder owns results/).
+	if err := os.MkdirAll(filepath.Join(queue, "results"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(queue, "results", key+".ok"), []byte("/nix/store/xxx 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d, err = r.reconcileNixBuildQueue(context.Background(), knight, queue)
+	if err != nil {
+		t.Fatalf("result reconcile: %v", err)
+	}
+	if knight.Status.NixToolsHash != hash {
+		t.Fatalf("status hash = %q, want %q", knight.Status.NixToolsHash, hash)
+	}
+	if d != 0 {
+		t.Fatalf("expected no requeue after completion, got %v", d)
+	}
+	if _, err := os.Stat(filepath.Join(queue, "requests", key)); !os.IsNotExist(err) {
+		t.Fatal("request dir should be cleaned up after success")
+	}
+	if _, err := os.Stat(filepath.Join(queue, "results", key+".ok")); !os.IsNotExist(err) {
+		t.Fatal(".ok marker should be cleaned up after success")
+	}
+
+	// 4. Already published → no-op.
+	if _, err := r.reconcileNixBuildQueue(context.Background(), knight, queue); err != nil {
+		t.Fatalf("post-publish reconcile: %v", err)
+	}
+}
+
+// TestReconcileNixBuildQueue_Failure surfaces a builder .err without looping.
+func TestReconcileNixBuildQueue_Failure(t *testing.T) {
+	queue := t.TempDir()
+	r := &KnightReconciler{Recorder: record.NewFakeRecorder(100)}
+	knight := nixQueueKnight()
+	hash := knightpkg.NixToolsHash(knight)
+	key := knight.Name + "__" + hash
+
+	if _, err := r.reconcileNixBuildQueue(context.Background(), knight, queue); err != nil {
+		t.Fatalf("seed reconcile: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(queue, "results"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(queue, "results", key+".err"), []byte("boom\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d, err := r.reconcileNixBuildQueue(context.Background(), knight, queue)
+	if err != nil {
+		t.Fatalf("failure reconcile: %v", err)
+	}
+	if knight.Status.NixToolsHash == hash {
+		t.Fatal("status hash must not be set on a failed build")
+	}
+	if d <= 0 {
+		t.Fatal("a failed build should still requeue (slowly) for a retry window")
+	}
+}
+
+// TestPruneStaleBuildRequests drops requests/results for superseded hashes.
+func TestPruneStaleBuildRequests(t *testing.T) {
+	queue := t.TempDir()
+	r := &KnightReconciler{Recorder: record.NewFakeRecorder(100)}
+	mk := func(p string) {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mk(filepath.Join(queue, "requests", "agravain__OLDHASH", "ready"))
+	mk(filepath.Join(queue, "requests", "agravain__KEEP", "ready"))
+	mk(filepath.Join(queue, "requests", "kay__OTHER", "ready")) // different knight, untouched
+	mk(filepath.Join(queue, "results", "agravain__OLDHASH.err"))
+
+	r.pruneStaleBuildRequests("agravain", "KEEP", queue)
+
+	if _, err := os.Stat(filepath.Join(queue, "requests", "agravain__OLDHASH")); !os.IsNotExist(err) {
+		t.Fatal("stale request for agravain should be pruned")
+	}
+	if _, err := os.Stat(filepath.Join(queue, "results", "agravain__OLDHASH.err")); !os.IsNotExist(err) {
+		t.Fatal("stale result for agravain should be pruned")
+	}
+	if _, err := os.Stat(filepath.Join(queue, "requests", "agravain__KEEP")); err != nil {
+		t.Fatal("current-hash request must be kept")
+	}
+	if _, err := os.Stat(filepath.Join(queue, "requests", "kay__OTHER")); err != nil {
+		t.Fatal("another knight's request must not be touched")
+	}
+}


### PR DESCRIPTION
The operator/chart side of the #4 "persistent nix-daemon builder" (pairs with pi-knight#35 and a GitOps queue PVC).

## Operator

`reconcileNixBuild` now prefers a queue-backed builder over the per-knight build Job:
- When the build-queue PVC is mounted (`BUILD_QUEUE_DIR`, default `/queue`), it writes a request (`requests/<knight>__<hash>/{flake.nix,ready}`) and **polls** for the builder's result (queue results are files, not watched objects — so Reconcile returns a requeue while pending). On `results/<key>.ok` it records `status.nixToolsHash`; on `.ok` cleanup + stale-hash pruning keep the queue tidy.
- When the queue is **absent**, it falls back to the legacy build-Job path unchanged (`reconcileNixBuildJob`), so this is a safe, gated migration.

This removes the global store flock that serialized fleet rebuilds — the builder runs requests concurrently against a single `nix-daemon` (correct fine-grained store concurrency + derivation dedup). A failed build surfaces a `NixBuildFailed` event without auto-looping on a genuinely broken flake.

## Chart

- `nixBuilder.*` values (disabled by default).
- `templates/nix-builder.yaml`: single-replica, root, `Recreate` Deployment — store PVC RW + queue PVC + emptyDir scratch; no fsGroup (store paths are world-readable 0555; avoids a recursive chown of the 30Gi store).
- operator Deployment gains an optional `/queue` mount + `BUILD_QUEUE_DIR` env when `nixBuilder.enabled && mountQueue`.
- Chart `0.10.4 → 0.11.0`.

## Tests

`knight_nixqueue_test.go` covers the request→result lifecycle, failure surfacing, and stale-hash pruning. Full controller suite (envtest) green; `go vet`/`gofmt` clean.

## Deploy (after merge + CI)

Create the queue PVC (GitOps), then bump the HelmRelease to chart 0.11.0 + new operator/pi-knight SHAs + `nixBuilder.enabled=true`.