### PR TITLE
feat: cut knights over to the read-only shared Nix store

### DIFF
--- a/charts/roundtable-operator/Chart.yaml
+++ b/charts/roundtable-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: roundtable-operator
 description: Knights of the Round Table — A Kubernetes Operator for Multi-Agent AI Orchestration
 type: application
-version: 0.11.0
+version: 0.12.0
 appVersion: "1.0.0"
 keywords:
   - ai

--- a/charts/roundtable-operator/templates/deployment.yaml
+++ b/charts/roundtable-operator/templates/deployment.yaml
@@ -57,6 +57,11 @@ spec:
             # Pinned nixpkgs ref for reproducible knight tool builds.
             - name: KNIGHT_NIXPKGS_REF
               value: "{{ .Values.nixpkgs.ref }}"
+            # Shared Nix store PVC — knights mount it read-only and the legacy
+            # build Job mounts it read-write. Single source of truth for the
+            # store name (the builder Deployment mounts the same value).
+            - name: KNIGHT_NIX_STORE_PVC
+              value: "{{ .Values.nixBuilder.storeClaimName }}"
             {{- if and .Values.nixBuilder.enabled .Values.nixBuilder.mountQueue }}
             # Presence of /queue switches the operator to queue-backed dispatch
             # (the nix-daemon builder) instead of per-knight build Jobs.

--- a/internal/controller/knight_controller.go
+++ b/internal/controller/knight_controller.go
@@ -386,80 +386,19 @@ func (r *KnightReconciler) reconcileConfigMap(ctx context.Context, knight *aiv1a
 
 // reconcilePVC creates the knight's persistent workspace volume.
 // Skips creation when spec.workspace.existingClaim is set (migration mode).
+//
+// Nix tooling no longer gets a per-knight PVC: knights mount the shared Nix
+// store read-only (see PodBuilder.WithNixStore) and source the profile the
+// nix-builder Deployment publishes. The legacy per-knight knight-<name>-nix
+// PVCs are left in place for rollback and removed by the separate decommission
+// step.
 func (r *KnightReconciler) reconcilePVC(ctx context.Context, knight *aiv1alpha1.Knight) error {
 	// Workspace PVC — skip if using an existing claim (migration mode)
 	if knight.Spec.Workspace != nil && knight.Spec.Workspace.ExistingClaim != "" {
 		logf.FromContext(ctx).Info("Using existing PVC", "claim", knight.Spec.Workspace.ExistingClaim)
-	} else {
-		if err := r.ensureWorkspacePVC(ctx, knight); err != nil {
-			return err
-		}
+		return nil
 	}
-
-	// Create Nix PVC if nix tools are configured, recycle if tools changed
-	hasNixTools := (knight.Spec.Tools != nil && len(knight.Spec.Tools.Nix) > 0) || len(knight.Spec.NixPackages) > 0
-	if hasNixTools {
-		nixPVCName := fmt.Sprintf("knight-%s-nix", knight.Name)
-		currentHash := knightpkg.NixToolsHash(knight)
-		nixPVC := &corev1.PersistentVolumeClaim{}
-		err := r.Get(ctx, types.NamespacedName{Name: nixPVCName, Namespace: knight.Namespace}, nixPVC)
-
-		if err == nil {
-			// PVC exists — check if tools changed
-			existingHash := nixPVC.Annotations[nixToolsHashAnnotation]
-			if existingHash != "" && existingHash != currentHash {
-				logf.FromContext(ctx).Info("Nix tools changed — recycling PVC",
-					"name", nixPVCName,
-					"oldHash", existingHash,
-					"newHash", currentHash)
-				r.Recorder.Event(knight, corev1.EventTypeNormal, "NixPVCCleaned", "Stale Nix PVC deleted due to tools change")
-				if err := r.Delete(ctx, nixPVC); err != nil {
-					return fmt.Errorf("Nix PVC delete for recycle failed: %w", err)
-				}
-				// Return early — next reconcile will create the fresh PVC
-				// The Deployment will be updated with the new hash annotation,
-				// triggering a rolling restart that waits for the new PVC.
-				return nil
-			}
-		}
-
-		if apierrors.IsNotFound(err) {
-			nixPVC = &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      nixPVCName,
-					Namespace: knight.Namespace,
-					Labels: map[string]string{
-						"app.kubernetes.io/name":       "knight",
-						"app.kubernetes.io/instance":   knight.Name,
-						"app.kubernetes.io/managed-by": "roundtable-operator",
-						"roundtable.io/purpose":        "nix-store",
-					},
-					Annotations: map[string]string{
-						nixToolsHashAnnotation: currentHash,
-					},
-				},
-				Spec: corev1.PersistentVolumeClaimSpec{
-					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-					Resources: corev1.VolumeResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceStorage: resource.MustParse("5Gi"),
-						},
-					},
-				},
-			}
-			if err := controllerutil.SetControllerReference(knight, nixPVC, r.Scheme); err != nil {
-				return err
-			}
-			if err := r.Create(ctx, nixPVC); err != nil {
-				return fmt.Errorf("Nix PVC create failed: %w", err)
-			}
-			logf.FromContext(ctx).Info("Nix PVC created", "name", nixPVCName, "toolsHash", currentHash)
-		} else if err != nil {
-			return fmt.Errorf("Nix PVC get failed: %w", err)
-		}
-	}
-
-	return nil
+	return r.ensureWorkspacePVC(ctx, knight)
 }
 
 // ensureWorkspacePVC creates a new workspace PVC if one doesn't exist.

--- a/internal/controller/knight_controller_test.go
+++ b/internal/controller/knight_controller_test.go
@@ -336,7 +336,7 @@ var _ = Describe("Knight Controller", func() {
 		})
 	})
 
-	Describe("Nix PVC Cleanup", func() {
+	Describe("Nix store (shared read-only cutover)", func() {
 		var (
 			ctx                context.Context
 			reconciler         *KnightReconciler
@@ -352,17 +352,12 @@ var _ = Describe("Knight Controller", func() {
 				Scheme:   k8sClient.Scheme(),
 				Recorder: record.NewFakeRecorder(100),
 			}
-			knightName = "test-nix-cleanup"
+			knightName = "test-nix-shared"
 			knightNamespace = "default"
-			typeNamespacedName = types.NamespacedName{
-				Name:      knightName,
-				Namespace: knightNamespace,
-			}
+			typeNamespacedName = types.NamespacedName{Name: knightName, Namespace: knightNamespace}
 		})
 
 		AfterEach(func() {
-			// Delete the knight and reconcile once so the controller removes
-			// its finalizer — no manager is running reconciles for us here.
 			knight := &aiv1alpha1.Knight{}
 			if err := k8sClient.Get(ctx, typeNamespacedName, knight); err == nil {
 				_ = k8sClient.Delete(ctx, knight)
@@ -372,37 +367,30 @@ var _ = Describe("Knight Controller", func() {
 				return errors.IsNotFound(k8sClient.Get(ctx, typeNamespacedName, &aiv1alpha1.Knight{}))
 			}, "5s", "100ms").Should(BeTrue())
 
-			// Delete leftover PVCs. envtest runs no kube-controller-manager,
-			// so the pvc-protection finalizer never clears on its own — strip
-			// finalizers to let terminating PVCs actually go away.
-			for _, name := range []string{knightName, "knight-" + knightName + "-nix"} {
-				key := types.NamespacedName{Name: name, Namespace: knightNamespace}
-				pvc := &corev1.PersistentVolumeClaim{}
-				if err := k8sClient.Get(ctx, key, pvc); err == nil {
-					_ = k8sClient.Delete(ctx, pvc)
-				}
-				Eventually(func() bool {
-					pvc := &corev1.PersistentVolumeClaim{}
-					err := k8sClient.Get(ctx, key, pvc)
-					if errors.IsNotFound(err) {
-						return true
-					}
-					if err == nil && pvc.DeletionTimestamp != nil && len(pvc.Finalizers) > 0 {
-						pvc.Finalizers = nil
-						_ = k8sClient.Update(ctx, pvc)
-					}
-					return false
-				}, "5s", "100ms").Should(BeTrue())
+			// Strip the pvc-protection finalizer (no kube-controller-manager in
+			// envtest) so the workspace PVC actually gets deleted.
+			key := types.NamespacedName{Name: knightName, Namespace: knightNamespace}
+			if pvc := (&corev1.PersistentVolumeClaim{}); k8sClient.Get(ctx, key, pvc) == nil {
+				_ = k8sClient.Delete(ctx, pvc)
 			}
+			Eventually(func() bool {
+				pvc := &corev1.PersistentVolumeClaim{}
+				err := k8sClient.Get(ctx, key, pvc)
+				if errors.IsNotFound(err) {
+					return true
+				}
+				if err == nil && pvc.DeletionTimestamp != nil && len(pvc.Finalizers) > 0 {
+					pvc.Finalizers = nil
+					_ = k8sClient.Update(ctx, pvc)
+				}
+				return false
+			}, "5s", "100ms").Should(BeTrue())
 		})
 
-		It("should delete Nix PVC when knight nix tools change", func() {
-			By("Creating a knight with initial Nix tools")
+		It("does not provision a per-knight Nix PVC (knights mount the shared store)", func() {
+			By("Creating a knight with Nix tools")
 			knight := &aiv1alpha1.Knight{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      knightName,
-					Namespace: knightNamespace,
-				},
+				ObjectMeta: metav1.ObjectMeta{Name: knightName, Namespace: knightNamespace},
 				Spec: aiv1alpha1.KnightSpec{
 					Domain: "devops",
 					Model:  "claude-sonnet-4-20250514",
@@ -413,193 +401,25 @@ var _ = Describe("Knight Controller", func() {
 						Stream:        "test_tasks",
 						ResultsStream: "test_results",
 					},
-					Tools: &aiv1alpha1.KnightTools{
-						Nix: []string{"nmap", "curl"},
-					},
+					Tools: &aiv1alpha1.KnightTools{Nix: []string{"nmap", "curl"}},
 				},
 			}
 			Expect(k8sClient.Create(ctx, knight)).To(Succeed())
 
-			By("Reconciling to create initial Nix PVC")
+			By("Reconciling")
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Verifying Nix PVC was created with initial hash")
-			nixPVCName := "knight-" + knightName + "-nix"
-			pvc := &corev1.PersistentVolumeClaim{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      nixPVCName,
+			By("Verifying the workspace PVC exists but no per-knight Nix PVC was created")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: knightName, Namespace: knightNamespace},
+				&corev1.PersistentVolumeClaim{})).To(Succeed())
+
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "knight-" + knightName + "-nix",
 				Namespace: knightNamespace,
-			}, pvc)).To(Succeed())
-
-			initialHash := pvc.Annotations["roundtable.io/nix-tools-hash"]
-			Expect(initialHash).NotTo(BeEmpty())
-			initialUID := pvc.UID
-
-			By("Changing the knight's Nix tools")
-			Expect(k8sClient.Get(ctx, typeNamespacedName, knight)).To(Succeed())
-			knight.Spec.Tools.Nix = []string{"nmap", "curl", "wget"}
-			Expect(k8sClient.Update(ctx, knight)).To(Succeed())
-
-			By("Reconciling after tool change")
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying old PVC was deleted")
-			// The old PVC should be gone (deleted during reconcile). envtest
-			// has no kube-controller-manager to clear the pvc-protection
-			// finalizer, so strip finalizers from the terminating PVC to let
-			// the deletion complete.
-			Eventually(func() bool {
-				oldPVC := &corev1.PersistentVolumeClaim{}
-				err := k8sClient.Get(ctx, types.NamespacedName{
-					Name:      nixPVCName,
-					Namespace: knightNamespace,
-				}, oldPVC)
-				if errors.IsNotFound(err) || (err == nil && oldPVC.UID != initialUID) {
-					return true
-				}
-				if err == nil && oldPVC.DeletionTimestamp != nil && len(oldPVC.Finalizers) > 0 {
-					oldPVC.Finalizers = nil
-					_ = k8sClient.Update(ctx, oldPVC)
-				}
-				return false
-			}, "10s", "1s").Should(BeTrue())
-		})
-
-		It("should delete Nix PVC when knight nixPackages change", func() {
-			By("Creating a knight with initial nixPackages")
-			knight := &aiv1alpha1.Knight{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      knightName,
-					Namespace: knightNamespace,
-				},
-				Spec: aiv1alpha1.KnightSpec{
-					Domain:      "devops",
-					Model:       "claude-sonnet-4-20250514",
-					Skills:      []string{"shared"},
-					NixPackages: []string{"git", "jq"},
-					NATS: aiv1alpha1.KnightNATS{
-						URL:           "nats://nats.test:4222",
-						Subjects:      []string{"test.tasks.devops.>"},
-						Stream:        "test_tasks",
-						ResultsStream: "test_results",
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, knight)).To(Succeed())
-
-			By("Reconciling to create initial Nix PVC")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying Nix PVC was created")
-			nixPVCName := "knight-" + knightName + "-nix"
-			pvc := &corev1.PersistentVolumeClaim{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      nixPVCName,
-				Namespace: knightNamespace,
-			}, pvc)).To(Succeed())
-
-			initialUID := pvc.UID
-
-			By("Changing the knight's nixPackages")
-			Expect(k8sClient.Get(ctx, typeNamespacedName, knight)).To(Succeed())
-			knight.Spec.NixPackages = []string{"git", "jq", "kubectl"}
-			Expect(k8sClient.Update(ctx, knight)).To(Succeed())
-
-			By("Reconciling after nixPackages change")
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying old PVC was deleted")
-			// envtest has no kube-controller-manager to clear the
-			// pvc-protection finalizer — strip finalizers from the
-			// terminating PVC so the deletion can complete.
-			Eventually(func() bool {
-				oldPVC := &corev1.PersistentVolumeClaim{}
-				err := k8sClient.Get(ctx, types.NamespacedName{
-					Name:      nixPVCName,
-					Namespace: knightNamespace,
-				}, oldPVC)
-				if errors.IsNotFound(err) || (err == nil && oldPVC.UID != initialUID) {
-					return true
-				}
-				if err == nil && oldPVC.DeletionTimestamp != nil && len(oldPVC.Finalizers) > 0 {
-					oldPVC.Finalizers = nil
-					_ = k8sClient.Update(ctx, oldPVC)
-				}
-				return false
-			}, "10s", "1s").Should(BeTrue())
-		})
-
-		It("should handle both Tools.Nix and NixPackages in hash", func() {
-			By("Creating a knight with both Tools.Nix and NixPackages")
-			knight := &aiv1alpha1.Knight{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      knightName,
-					Namespace: knightNamespace,
-				},
-				Spec: aiv1alpha1.KnightSpec{
-					Domain:      "devops",
-					Model:       "claude-sonnet-4-20250514",
-					Skills:      []string{"shared"},
-					NixPackages: []string{"git"},
-					Tools: &aiv1alpha1.KnightTools{
-						Nix: []string{"curl"},
-					},
-					NATS: aiv1alpha1.KnightNATS{
-						URL:           "nats://nats.test:4222",
-						Subjects:      []string{"test.tasks.devops.>"},
-						Stream:        "test_tasks",
-						ResultsStream: "test_results",
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, knight)).To(Succeed())
-
-			By("Reconciling to create Nix PVC")
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying Nix PVC was created")
-			nixPVCName := "knight-" + knightName + "-nix"
-			pvc := &corev1.PersistentVolumeClaim{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      nixPVCName,
-				Namespace: knightNamespace,
-			}, pvc)).To(Succeed())
-
-			initialUID := pvc.UID
-
-			By("Changing only nixPackages while keeping Tools.Nix same")
-			Expect(k8sClient.Get(ctx, typeNamespacedName, knight)).To(Succeed())
-			knight.Spec.NixPackages = []string{"git", "jq"}
-			Expect(k8sClient.Update(ctx, knight)).To(Succeed())
-
-			By("Reconciling after change")
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Verifying PVC was deleted due to combined hash change")
-			// envtest has no kube-controller-manager to clear the
-			// pvc-protection finalizer — strip finalizers from the
-			// terminating PVC so the deletion can complete.
-			Eventually(func() bool {
-				oldPVC := &corev1.PersistentVolumeClaim{}
-				err := k8sClient.Get(ctx, types.NamespacedName{
-					Name:      nixPVCName,
-					Namespace: knightNamespace,
-				}, oldPVC)
-				if errors.IsNotFound(err) || (err == nil && oldPVC.UID != initialUID) {
-					return true
-				}
-				if err == nil && oldPVC.DeletionTimestamp != nil && len(oldPVC.Finalizers) > 0 {
-					oldPVC.Finalizers = nil
-					_ = k8sClient.Update(ctx, oldPVC)
-				}
-				return false
-			}, "10s", "1s").Should(BeTrue())
+			}, &corev1.PersistentVolumeClaim{})
+			Expect(errors.IsNotFound(err)).To(BeTrue(),
+				"per-knight Nix PVC must not be created after the shared-store cutover")
 		})
 	})
 })

--- a/internal/controller/knight_nixbuild.go
+++ b/internal/controller/knight_nixbuild.go
@@ -33,11 +33,6 @@ import (
 	knightpkg "github.com/dapperdivers/roundtable/internal/knight"
 )
 
-// sharedNixStorePVCName is the cluster-wide RWX PVC backing the shared Nix
-// store. The build Job mounts it read-write; knight pods mount it read-only.
-// Provisioned out-of-band via GitOps; the build feature is inert until it exists.
-const sharedNixStorePVCName = "roundtable-nix-store"
-
 // nixBuildJobTTL keeps finished build Jobs around briefly for log inspection
 // before Kubernetes garbage-collects them.
 const nixBuildJobTTL int32 = 3600
@@ -63,7 +58,7 @@ func (r *KnightReconciler) reconcileNixBuildJob(ctx context.Context, knight *aiv
 
 	// Feature gate: only act when the shared store exists.
 	shared := &corev1.PersistentVolumeClaim{}
-	if err := r.Get(ctx, types.NamespacedName{Name: sharedNixStorePVCName, Namespace: knight.Namespace}, shared); err != nil {
+	if err := r.Get(ctx, types.NamespacedName{Name: knightpkg.SharedNixStorePVC(), Namespace: knight.Namespace}, shared); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil // shared store not provisioned yet — legacy per-pod build still applies
 		}
@@ -184,7 +179,7 @@ func (r *KnightReconciler) buildNixBuildJob(knight *aiv1alpha1.Knight, hash, job
 							Name: "nix",
 							VolumeSource: corev1.VolumeSource{
 								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-									ClaimName: sharedNixStorePVCName,
+									ClaimName: knightpkg.SharedNixStorePVC(),
 								},
 							},
 						},

--- a/internal/controller/knight_nixbuild_test.go
+++ b/internal/controller/knight_nixbuild_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Knight Nix build Job", func() {
 			for _, v := range pod.Volumes {
 				vols[v.Name] = v
 			}
-			Expect(vols["nix"].PersistentVolumeClaim.ClaimName).To(Equal(sharedNixStorePVCName))
+			Expect(vols["nix"].PersistentVolumeClaim.ClaimName).To(Equal(knightpkg.SharedNixStorePVC()))
 			Expect(vols["config"].ConfigMap.Name).To(Equal("knight-galahad-config"))
 			Expect(vols["scratch"].EmptyDir).NotTo(BeNil())
 
@@ -122,7 +122,7 @@ var _ = Describe("Knight Nix build Job", func() {
 
 		It("creates a build Job once the shared store exists", func() {
 			pvc := &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{Name: sharedNixStorePVCName, Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Name: knightpkg.SharedNixStorePVC(), Namespace: "default"},
 				Spec: corev1.PersistentVolumeClaimSpec{
 					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
 					Resources: corev1.VolumeResourceRequirements{

--- a/internal/knight/pod_builder.go
+++ b/internal/knight/pod_builder.go
@@ -19,6 +19,7 @@ package knight
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -127,21 +128,49 @@ func (b *PodBuilder) WithConfig(configMapName string) *PodBuilder {
 	return b
 }
 
-// WithNixStore adds the Nix PVC mount at /nix if tools.nix is configured.
+// defaultSharedNixStorePVC is the fallback name of the cluster-wide RWX Nix
+// store when KNIGHT_NIX_STORE_PVC is unset.
+const defaultSharedNixStorePVC = "roundtable-nix-store"
+
+// SharedNixStorePVC returns the name of the shared Nix store PVC. It is
+// configurable via the KNIGHT_NIX_STORE_PVC env, which the chart sets from
+// nixBuilder.storeClaimName — the same value the builder Deployment mounts — so
+// the writer (builder) and readers (knights, legacy build Job) never drift.
+func SharedNixStorePVC() string {
+	if v := os.Getenv("KNIGHT_NIX_STORE_PVC"); v != "" {
+		return v
+	}
+	return defaultSharedNixStorePVC
+}
+
+// WithNixStore mounts the shared Nix store read-only at /nix when the knight has
+// nix tools, and points the entrypoint at its published profile. The store is
+// built by the operator's nix-builder; the knight never writes to it — a
+// read-only mount also makes kubelet skip the fsGroup chown of the large store.
+// Tools resolve via the profile's bin dir, already on the container PATH
+// (knightToolPATH). The entrypoint detects the read-only /nix and sources the
+// profile instead of bootstrapping a per-pod store.
 func (b *PodBuilder) WithNixStore() *PodBuilder {
 	if b.knight.Spec.Tools != nil && len(b.knight.Spec.Tools.Nix) > 0 {
-		nixPVCName := fmt.Sprintf("knight-%s-nix", b.knight.Name)
 		b.volumes = append(b.volumes, corev1.Volume{
 			Name: "nix",
 			VolumeSource: corev1.VolumeSource{
 				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: nixPVCName,
+					ClaimName: SharedNixStorePVC(),
+					ReadOnly:  true,
 				},
 			},
 		})
 		b.mounts = append(b.mounts, corev1.VolumeMount{
 			Name:      "nix",
 			MountPath: "/nix",
+			ReadOnly:  true,
+		})
+		// CR names are RFC1123 lowercase — matches the profile key the builder
+		// publishes (and the entrypoint's KNIGHT_NAME-derived default).
+		b.env = append(b.env, corev1.EnvVar{
+			Name:  "KNIGHT_NIX_PROFILE",
+			Value: "/nix/var/nix/profiles/knights/" + b.knight.Name,
 		})
 	}
 	return b

--- a/internal/knight/pod_builder_test.go
+++ b/internal/knight/pod_builder_test.go
@@ -105,7 +105,7 @@ var _ = Describe("PodBuilder", func() {
 			Expect(builder.mounts).To(BeEmpty())
 		})
 
-		It("adds Nix PVC when tools.nix is configured", func() {
+		It("mounts the shared store read-only when tools.nix is configured", func() {
 			knight.Spec.Tools = &aiv1alpha1.KnightTools{
 				Nix: []string{"kubectl", "helm"},
 			}
@@ -113,11 +113,28 @@ var _ = Describe("PodBuilder", func() {
 
 			Expect(builder.volumes).To(HaveLen(1))
 			Expect(builder.volumes[0].Name).To(Equal("nix"))
-			Expect(builder.volumes[0].PersistentVolumeClaim.ClaimName).To(Equal("knight-test-knight-nix"))
+			Expect(builder.volumes[0].PersistentVolumeClaim.ClaimName).To(Equal("roundtable-nix-store"))
+			Expect(builder.volumes[0].PersistentVolumeClaim.ReadOnly).To(BeTrue())
 
 			Expect(builder.mounts).To(HaveLen(1))
 			Expect(builder.mounts[0].Name).To(Equal("nix"))
 			Expect(builder.mounts[0].MountPath).To(Equal("/nix"))
+			Expect(builder.mounts[0].ReadOnly).To(BeTrue())
+
+			// Points the entrypoint at the knight's published profile.
+			Expect(builder.env).To(ContainElement(corev1.EnvVar{
+				Name:  "KNIGHT_NIX_PROFILE",
+				Value: "/nix/var/nix/profiles/knights/test-knight",
+			}))
+		})
+
+		It("honors KNIGHT_NIX_STORE_PVC override", func() {
+			GinkgoT().Setenv("KNIGHT_NIX_STORE_PVC", "custom-store")
+			knight.Spec.Tools = &aiv1alpha1.KnightTools{Nix: []string{"kubectl"}}
+			builder.WithNixStore()
+
+			Expect(builder.volumes).To(HaveLen(1))
+			Expect(builder.volumes[0].PersistentVolumeClaim.ClaimName).To(Equal("custom-store"))
 		})
 	})
 


### PR DESCRIPTION
The #13 cutover — knights now **consume** the shared Nix store the daemon builder populates, instead of each running a 5Gi per-pod RWO store.

## Changes
- **`WithNixStore()`** mounts `roundtable-nix-store` **ReadOnly** at `/nix` and injects `KNIGHT_NIX_PROFILE=/nix/var/nix/profiles/knights/<name>`. The pi-knight entrypoint already detects a read-only `/nix` (`[ ! -w /nix ]`), sources the published profile, and skips Phase 2/3 local bootstrap+build — so **no pi-knight change** is needed. A read-only mount also makes kubelet skip the fsGroup chown of the large store.
- **`reconcilePVC()`** no longer creates per-knight `knight-<name>-nix` PVCs. Existing ones are left in place (rollback safety) and removed by the separate decommission step.
- **Configurable store name:** the PVC name is now read from `KNIGHT_NIX_STORE_PVC` (defaulting to `roundtable-nix-store`), which the chart sets from `nixBuilder.storeClaimName` — one source of truth for the builder (writer), knights (readers), and the legacy build Job. (Addresses review feedback: no more hardcoded name.)
- Chart `0.11.0 → 0.12.0`.

## Safety / rollback
Reverting the HelmRelease restores the per-pod mounts — the per-knight PVCs still exist until decommission, so knight `/data` and tool state are intact. Prerequisite met: the shared store is **26/26** populated.

## Tests
Replaced the obsolete per-knight-PVC recycling specs with one asserting no per-knight Nix PVC is created post-cutover; `WithNixStore` specs now assert the read-only shared mount + `KNIGHT_NIX_PROFILE` + the `KNIGHT_NIX_STORE_PVC` override. Full controller (envtest) + knight suites green; `go vet`/`gofmt`/`helm lint` clean.