### PR TITLE
fix: deliver mission briefings to knight task subjects

### DIFF
--- a/internal/controller/mission_briefing_test.go
+++ b/internal/controller/mission_briefing_test.go
@@ -1,0 +1,253 @@
+/*
+Copyright 2026 dapperdivers.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/go-logr/logr"
+	"github.com/nats-io/nats.go"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+
+	aiv1alpha1 "github.com/dapperdivers/roundtable/api/v1alpha1"
+	natspkg "github.com/dapperdivers/roundtable/pkg/nats"
+)
+
+// fakeNATSClient is an in-memory natspkg.Client that records publishes and
+// fails subjects matched by failSubject.
+type fakeNATSClient struct {
+	mu          sync.Mutex
+	published   map[string][]byte
+	failSubject func(subject string) bool
+}
+
+func newFakeNATSClient() *fakeNATSClient {
+	return &fakeNATSClient{published: map[string][]byte{}}
+}
+
+func (f *fakeNATSClient) subjects() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, 0, len(f.published))
+	for s := range f.published {
+		out = append(out, s)
+	}
+	return out
+}
+
+func (f *fakeNATSClient) Connect() error     { return nil }
+func (f *fakeNATSClient) Close() error       { return nil }
+func (f *fakeNATSClient) IsConnected() bool  { return true }
+
+func (f *fakeNATSClient) Publish(subject string, data []byte) error {
+	if f.failSubject != nil && f.failSubject(subject) {
+		return fmt.Errorf("NATS publish to %s failed: nats: no response from stream", subject)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.published[subject] = data
+	return nil
+}
+
+func (f *fakeNATSClient) PublishJSON(subject string, v interface{}) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	return f.Publish(subject, data)
+}
+
+func (f *fakeNATSClient) Subscribe(string, ...natspkg.SubscribeOption) (*nats.Subscription, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (f *fakeNATSClient) CreateStream(natspkg.StreamConfig) error { return nil }
+func (f *fakeNATSClient) DeleteStream(string) error               { return nil }
+func (f *fakeNATSClient) StreamInfo(string) (*nats.StreamInfo, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (f *fakeNATSClient) EnsureConsumer(string, string, natspkg.ConsumerConfig) error { return nil }
+func (f *fakeNATSClient) DeleteConsumer(string, string) error                         { return nil }
+func (f *fakeNATSClient) PollMessage(string, time.Duration, ...natspkg.SubscribeOption) (*nats.Msg, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (f *fakeNATSClient) KVPut(string, string, []byte) error { return nil }
+func (f *fakeNATSClient) KVGet(string, string) ([]byte, error) {
+	return nil, fmt.Errorf("not found")
+}
+func (f *fakeNATSClient) KVDelete(string, string) error    { return nil }
+func (f *fakeNATSClient) KVKeys(string) ([]string, error)  { return nil, nil }
+
+var _ = Describe("MissionReconciler.publishBriefing", func() {
+	const namespace = "default"
+	ctx := context.Background()
+
+	var (
+		fake       *fakeNATSClient
+		reconciler *MissionReconciler
+		cleanup    []func()
+	)
+
+	newReconciler := func() *MissionReconciler {
+		return &MissionReconciler{
+			Client:   k8sClient,
+			Scheme:   k8sClient.Scheme(),
+			Recorder: record.NewFakeRecorder(10),
+			NATS:     natspkg.NewProviderWithClient(fake, logr.Discard()),
+		}
+	}
+
+	createKnight := func(name string, subjects []string) {
+		knight := &aiv1alpha1.Knight{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec: aiv1alpha1.KnightSpec{
+				Domain: "operator",
+				Model:  "claude-sonnet-4",
+				Skills: []string{"general"},
+				NATS: aiv1alpha1.KnightNATS{
+					URL:           "nats://nats.test:4222",
+					Subjects:      subjects,
+					Stream:        "rt_dev_tasks",
+					ResultsStream: "rt_dev_results",
+				},
+				Concurrency: 1,
+				TaskTimeout: 120,
+			},
+		}
+		Expect(k8sClient.Create(ctx, knight)).To(Succeed())
+		cleanup = append(cleanup, func() { _ = k8sClient.Delete(ctx, knight) })
+	}
+
+	createRoundTable := func(name, prefix string) {
+		rt := &aiv1alpha1.RoundTable{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec: aiv1alpha1.RoundTableSpec{
+				NATS: aiv1alpha1.RoundTableNATS{
+					URL:           "nats://nats.test:4222",
+					SubjectPrefix: prefix,
+					TasksStream:   "rt_dev_tasks",
+					ResultsStream: "rt_dev_results",
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, rt)).To(Succeed())
+		cleanup = append(cleanup, func() { _ = k8sClient.Delete(ctx, rt) })
+	}
+
+	newMission := func(name string, knights ...string) *aiv1alpha1.Mission {
+		mks := make([]aiv1alpha1.MissionKnight, 0, len(knights))
+		for _, k := range knights {
+			mks = append(mks, aiv1alpha1.MissionKnight{Name: k})
+		}
+		return &aiv1alpha1.Mission{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Generation: 1},
+			Spec: aiv1alpha1.MissionSpec{
+				Objective: "test objective",
+				Briefing:  "test briefing",
+				Knights:   mks,
+			},
+		}
+	}
+
+	BeforeEach(func() {
+		fake = newFakeNATSClient()
+		reconciler = newReconciler()
+		cleanup = nil
+	})
+
+	AfterEach(func() {
+		for _, fn := range cleanup {
+			fn()
+		}
+	})
+
+	It("publishes only to knight task subjects, never a .briefing broadcast", func() {
+		createKnight("brief-knight-a", []string{"rt-dev.tasks.operator.>"})
+		mission := newMission("brief-m1", "brief-knight-a")
+
+		Expect(reconciler.publishBriefing(ctx, mission)).To(Succeed())
+
+		subjects := fake.subjects()
+		Expect(subjects).To(ConsistOf("rt-dev.tasks.operator.brief-knight-a"))
+		for _, s := range subjects {
+			Expect(strings.HasSuffix(s, ".briefing")).To(BeFalse(),
+				"no stream covers *.briefing — publishing there can never be acked")
+		}
+	})
+
+	It("falls back to the referenced RoundTable's prefix when knight subjects are unparseable", func() {
+		createKnight("brief-knight-b", []string{"malformed-subject"})
+		createRoundTable("brief-rt", "rt-dev")
+		mission := newMission("brief-m2", "brief-knight-b")
+		mission.Spec.RoundTableRef = "brief-rt"
+
+		Expect(reconciler.publishBriefing(ctx, mission)).To(Succeed())
+		Expect(fake.subjects()).To(ConsistOf("rt-dev.tasks.operator.brief-knight-b"))
+	})
+
+	It("uses a generation-based task ID so retries are idempotent", func() {
+		createKnight("brief-knight-c", []string{"rt-dev.tasks.operator.>"})
+		mission := newMission("brief-m3", "brief-knight-c")
+
+		Expect(reconciler.publishBriefing(ctx, mission)).To(Succeed())
+
+		var payload natspkg.TaskPayload
+		data := fake.published["rt-dev.tasks.operator.brief-knight-c"]
+		Expect(json.Unmarshal(data, &payload)).To(Succeed())
+		Expect(payload.TaskID).To(Equal("mission-brief-m3-briefing-brief-knight-c-gen1"))
+	})
+
+	It("returns an error when no knight received the briefing", func() {
+		createKnight("brief-knight-d", []string{"rt-dev.tasks.operator.>"})
+		mission := newMission("brief-m4", "brief-knight-d")
+		fake.failSubject = func(string) bool { return true }
+
+		err := reconciler.publishBriefing(ctx, mission)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not delivered to any"))
+	})
+
+	It("succeeds with a warning when only some knights received the briefing", func() {
+		createKnight("brief-knight-e", []string{"rt-dev.tasks.operator.>"})
+		createKnight("brief-knight-f", []string{"rt-dev.tasks.operator.>"})
+		mission := newMission("brief-m5", "brief-knight-e", "brief-knight-f")
+		fake.failSubject = func(subject string) bool {
+			return strings.HasSuffix(subject, "brief-knight-f")
+		}
+
+		Expect(reconciler.publishBriefing(ctx, mission)).To(Succeed())
+		Expect(fake.subjects()).To(ConsistOf("rt-dev.tasks.operator.brief-knight-e"))
+
+		recorder := reconciler.Recorder.(*record.FakeRecorder)
+		Eventually(recorder.Events).Should(Receive(ContainSubstring("BriefingPartialDelivery")))
+	})
+
+	It("skips ephemeral knights without error", func() {
+		mission := newMission("brief-m6")
+		mission.Spec.Knights = []aiv1alpha1.MissionKnight{{Name: "ghost", Ephemeral: true}}
+
+		Expect(reconciler.publishBriefing(ctx, mission)).To(Succeed())
+		Expect(fake.subjects()).To(BeEmpty())
+	})
+})

--- a/internal/controller/mission_controller.go
+++ b/internal/controller/mission_controller.go
@@ -46,14 +46,6 @@ const (
 	missionFinalizer = "ai.roundtable.io/mission-finalizer"
 )
 
-// BriefingPayload is the JSON payload published to NATS for mission briefings.
-type BriefingPayload struct {
-	MissionName string   `json:"missionName"`
-	Objective   string   `json:"objective"`
-	Briefing    string   `json:"briefing"`
-	Knights     []string `json:"knights"`
-}
-
 // MissionReconciler reconciles a Mission object.
 type MissionReconciler struct {
 	client.Client
@@ -901,54 +893,63 @@ func (r *MissionReconciler) updateKnightStatuses(ctx context.Context, mission *a
 	}
 }
 
-// publishBriefing publishes the mission briefing to NATS.
+// publishBriefing delivers the mission briefing to each named knight's task subject.
+//
+// There is deliberately no broadcast publish to "<prefix>.briefing": no JetStream
+// stream covers that subject on any provisioning path (RoundTable streams only
+// capture "<prefix>.tasks.>" and "<prefix>.results.>") and nothing subscribes to
+// it, so a JetStream publish there can never be acked. It wedged every briefed
+// mission at BriefingPublished=False/PublishFailed.
 func (r *MissionReconciler) publishBriefing(ctx context.Context, mission *aiv1alpha1.Mission) error {
+	log := logf.FromContext(ctx)
+
 	client, err := r.natsClient()
 	if err != nil {
 		return err
 	}
 
-	knightNames := make([]string, 0, len(mission.Spec.Knights))
-	for _, mk := range mission.Spec.Knights {
-		knightNames = append(knightNames, mk.Name)
+	// Fallback subject prefix for knights whose own subjects can't be parsed:
+	// prefer the referenced RoundTable's prefix (covered by its tasks stream)
+	// over the mission-scoped prefix, which only exists for ephemeral tables.
+	fallbackPrefix := natsPrefix(mission)
+	if mission.Spec.RoundTableRef != "" {
+		rt := &aiv1alpha1.RoundTable{}
+		if err := r.Get(ctx, types.NamespacedName{
+			Name:      mission.Spec.RoundTableRef,
+			Namespace: mission.Namespace,
+		}, rt); err == nil && rt.Spec.NATS.SubjectPrefix != "" {
+			fallbackPrefix = rt.Spec.NATS.SubjectPrefix
+		}
 	}
 
-	payload := BriefingPayload{
-		MissionName: mission.Name,
-		Objective:   mission.Spec.Objective,
-		Briefing:    mission.Spec.Briefing,
-		Knights:     knightNames,
-	}
-
-	// Publish to mission briefing subject
-	prefix := natsPrefix(mission)
-	subject := fmt.Sprintf("%s.briefing", prefix)
-	if err := client.PublishJSON(subject, payload); err != nil {
-		return err
-	}
-
-	// Also publish briefing as a task to each knight's normal task subject
+	attempted := 0
+	published := 0
 	for _, mk := range mission.Spec.Knights {
 		if mk.Ephemeral {
 			continue
 		}
+		attempted++
+
 		knight := &aiv1alpha1.Knight{}
 		if err := r.Get(ctx, types.NamespacedName{
 			Name:      mk.Name,
 			Namespace: mission.Namespace,
 		}, knight); err != nil {
+			log.Error(err, "Failed to get knight for briefing", "knight", mk.Name)
 			continue
 		}
 
 		taskPayload := natspkg.TaskPayload{
-			TaskID:    fmt.Sprintf("mission-%s-briefing-%d", mission.Name, time.Now().UnixMilli()),
+			// Generation-based TaskID so a retried publish carries the same ID
+			// (same idempotency pattern as the planner's dispatchPlanningTask).
+			TaskID:    fmt.Sprintf("mission-%s-briefing-%s-gen%d", mission.Name, mk.Name, mission.Generation),
 			ChainName: fmt.Sprintf("mission-%s", mission.Name),
 			StepName:  "briefing",
 			Task:      fmt.Sprintf("[Mission: %s]\nObjective: %s\n\n%s", mission.Name, mission.Spec.Objective, mission.Spec.Briefing),
 		}
 
 		// Derive subject prefix from the knight's NATS config
-		briefingPrefix := natsPrefix(mission)
+		briefingPrefix := fallbackPrefix
 		if len(knight.Spec.NATS.Subjects) > 0 {
 			parts := strings.SplitN(knight.Spec.NATS.Subjects[0], ".tasks.", 2)
 			if len(parts) == 2 {
@@ -957,10 +958,19 @@ func (r *MissionReconciler) publishBriefing(ctx context.Context, mission *aiv1al
 		}
 		taskSubject := natspkg.TaskSubject(briefingPrefix, knight.Spec.Domain, mk.Name)
 		if err := client.PublishJSON(taskSubject, taskPayload); err != nil {
-			logf.FromContext(ctx).Error(err, "Failed to publish briefing to knight", "knight", mk.Name)
+			log.Error(err, "Failed to publish briefing to knight", "knight", mk.Name, "subject", taskSubject)
+			continue
 		}
+		published++
 	}
 
+	if attempted > 0 && published == 0 {
+		return fmt.Errorf("briefing not delivered to any of %d knights", attempted)
+	}
+	if published < attempted {
+		r.Recorder.Eventf(mission, corev1.EventTypeWarning, "BriefingPartialDelivery",
+			"Briefing delivered to %d of %d knights", published, attempted)
+	}
 	return nil
 }
 

--- a/pkg/nats/provider.go
+++ b/pkg/nats/provider.go
@@ -42,6 +42,16 @@ func NewProvider(config Config, log logr.Logger) *Provider {
 	}
 }
 
+// NewProviderWithClient creates a Provider that wraps an existing client.
+// Intended for tests that need to inject a fake NATS client; the client
+// is returned as-is from Client() while it reports IsConnected.
+func NewProviderWithClient(client Client, log logr.Logger) *Provider {
+	return &Provider{
+		client: client,
+		log:    log,
+	}
+}
+
 // Client returns the shared NATS client, connecting lazily on first call.
 // Subsequent calls return the same client instance if still connected.
 // Thread-safe for concurrent access from multiple controllers.


### PR DESCRIPTION
## Problem

Non-meta Missions with `roundTableRef` set (e.g. `rt-fix-pi-knight-ci` on `roundtable-dev`) wedged at `BriefingPublished=False/PublishFailed` with:

```
NATS publish to mission-<name>.briefing failed: nats: no response from stream
```

Root cause: `publishBriefing` opened with a JetStream publish to `<natsPrefix(mission)>.briefing`. **No stream covers `*.briefing` on any provisioning path** — RoundTable streams only capture `<prefix>.tasks.>` and `<prefix>.results.>`, and the ephemeral path's prefix (`msn-<name>-<uid8>`) doesn't cover it either. Nothing subscribes to the subject anywhere in the stack, so the JS publish can never be acked and the mission never leaves Briefing. This blocks Night Watch Phase 2 (watchman Mission dispatch).

## Fix

- Remove the dead `.briefing` broadcast (and the now-unused `BriefingPayload`); the per-knight task publishes are the actual delivery path
- When a knight's own subjects can't be parsed, fall back to the referenced RoundTable's `spec.nats.subjectPrefix` instead of the uncovered `mission-<name>` prefix
- Generation-based briefing TaskID (was wall-clock ms) so retried publishes are idempotent — same pattern as the planner's `dispatchPlanningTask`
- Per-knight failures no longer silently swallowed: the phase fails (and retries) only when **no** knight received the briefing; partial delivery emits a `BriefingPartialDelivery` warning event

## Testing

- New `publishBriefing` specs via a fake NATS client (`NewProviderWithClient` test seam): no broadcast subject, RT-prefix fallback, idempotent TaskID, all-fail error, partial-delivery warning, ephemeral skip
- Full non-e2e suite green locally