### PR TITLE
chore: bump chart to 0.12.2 — pin dashboard and pi-knight images

### DIFF
--- a/charts/roundtable-operator/Chart.yaml
+++ b/charts/roundtable-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: roundtable-operator
 description: Knights of the Round Table — A Kubernetes Operator for Multi-Agent AI Orchestration
 type: application
-version: 0.12.1
+version: 0.12.2
 appVersion: "1.0.0"
 keywords:
   - ai

--- a/charts/roundtable-operator/values.yaml
+++ b/charts/roundtable-operator/values.yaml
@@ -30,14 +30,16 @@ affinity: {}
 # Additional args to pass to the manager
 extraArgs: []
 
-# Global image settings for managed components
+# Global image settings for managed components — pinned to git SHAs of each
+# repo's main; bump here (with a chart version bump), then update the chart
+# version in dapper-cluster
 images:
   piKnight:
     repository: ghcr.io/dapperdivers/pi-knight
-    tag: latest
+    tag: 7abd75f6ce2141cf554a9be97ef79f05f4fd0336
   dashboard:
     repository: ghcr.io/dapperdivers/roundtable-ui
-    tag: latest
+    tag: 12a92251764f03f3cab2ebe3668a648cad7b740d
 
 # Pod-level security context for all knight-owned pods — knight Deployments
 # AND the shared Nix store build Jobs. Set once here; the operator applies it


### PR DESCRIPTION
## What

- Chart `0.12.1` → `0.12.2`
- `images.dashboard.tag`: `latest` → `12a9225` — picks up [roundtable-ui #144](https://github.com/dapperdivers/roundtable-ui/pull/144) (forward-auth login removal, typed API client, shared UI primitives, chain metadata now returned by the dashboard API)
- `images.piKnight.tag`: `latest` → `7abd75f` — current pi-knight main; only CI changes vs the deployed image, identical runtime

Image SHAs are now pinned in the chart (previously `latest`, with the real pins living as helmrelease value overrides in dapper-cluster).

## Cluster follow-up (dapper-cluster PR for 0.12.2)

- Bump `spec.chart.spec.version` → `0.12.2` (+ operator image tag to this merge SHA)
- **Remove the `spec.values.images.piKnight.tag` and `spec.values.images.dashboard.tag` overrides** — they shadow these chart pins; leaving them means the old images keep running

## Testing

- `helm lint` ✅  `mise run operator:test` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)