### PR TITLE
chore: bump chart to 0.12.3 — dashboard crash fix

### DIFF
--- a/charts/roundtable-operator/Chart.yaml
+++ b/charts/roundtable-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: roundtable-operator
 description: Knights of the Round Table — A Kubernetes Operator for Multi-Agent AI Orchestration
 type: application
-version: 0.12.2
+version: 0.12.3
 appVersion: "1.0.0"
 keywords:
   - ai

--- a/charts/roundtable-operator/values.yaml
+++ b/charts/roundtable-operator/values.yaml
@@ -39,7 +39,7 @@ images:
     tag: 7abd75f6ce2141cf554a9be97ef79f05f4fd0336
   dashboard:
     repository: ghcr.io/dapperdivers/roundtable-ui
-    tag: 12a92251764f03f3cab2ebe3668a648cad7b740d
+    tag: f7fccb6d2318eca1250f0655a53a4f67a4855415
 
 # Pod-level security context for all knight-owned pods — knight Deployments
 # AND the shared Nix store build Jobs. Set once here; the operator applies it


### PR DESCRIPTION
Chart `0.12.2` → `0.12.3`; dashboard image `12a9225` → `f7fccb6`.

Picks up [roundtable-ui #145](https://github.com/dapperdivers/roundtable-ui/pull/145): a null-deref that white-screened the Missions page whenever a meta-mission existed (`knights`/`chains` are `null` until the operator assigns them). Caught by driving the merged UI against the live cluster.

**Supersedes #133's 0.12.2 pin**, which pointed at the pre-fix dashboard image — deploy 0.12.3, not 0.12.2.

## Cluster follow-up (dapper-cluster PR)

- `spec.chart.spec.version` → `0.12.3` (+ operator image tag to this merge SHA)
- **Remove the `spec.values.images.piKnight.tag` and `spec.values.images.dashboard.tag` overrides** — they shadow the chart pins

## Testing

- `helm lint` ✅
- The dashboard image was verified end-to-end against the live cluster (every page, real meta-mission dispatch, WebSocket, task dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)