### PR TITLE
fix: warm-pool claim breaks chain knightRefs; planning counters lost on spec update

### DIFF
--- a/internal/controller/mission_controller_test.go
+++ b/internal/controller/mission_controller_test.go
@@ -1502,14 +1502,24 @@ var _ = Describe("Mission Controller - Warm Pool", func() {
 				Assembler: &missionpkg.KnightAssembler{Client: k8sClient, Scheme: k8sClient.Scheme()},
 			}
 
-			// Drive to assembling phase
+			// Drive through Assembling — the warm pool claim recreates the knight
+			// under its mission-prefixed name, which starts not-ready; mark it
+			// ready as it appears so the mission can advance.
 			for i := 0; i < 10; i++ {
 				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: missionNN})
 				Expect(err).NotTo(HaveOccurred())
+				// Mark the recreated mission knight ready once it appears
+				claimKnight := &aiv1alpha1.Knight{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      missionName + "-knight1",
+					Namespace: namespace,
+				}, claimKnight); err == nil && !claimKnight.Status.Ready {
+					claimKnight.Status.Phase = aiv1alpha1.KnightPhaseReady
+					claimKnight.Status.Ready = true
+					_ = k8sClient.Status().Update(ctx, claimKnight)
+				}
 				mission := &aiv1alpha1.Mission{}
 				_ = k8sClient.Get(ctx, missionNN, mission)
-				// Keep reconciling through Assembling — the warm pool claim
-				// happens during the Assembling reconcile, not on entry to it.
 				if mission.Status.Phase == aiv1alpha1.MissionPhaseBriefing ||
 					mission.Status.Phase == aiv1alpha1.MissionPhaseActive {
 					break
@@ -1517,15 +1527,24 @@ var _ = Describe("Mission Controller - Warm Pool", func() {
 				time.Sleep(100 * time.Millisecond)
 			}
 
-			By("Verifying the warm knight was claimed")
-			claimedKnight := &aiv1alpha1.Knight{}
+			By("Verifying the claim created the mission-prefixed knight")
+			// Chain steps reference "<mission>-<knight>", so the claimed knight
+			// must exist under that name.
+			missionKnight := &aiv1alpha1.Knight{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      missionName + "-knight1",
+				Namespace: namespace,
+			}, missionKnight)).To(Succeed())
+			Expect(missionKnight.Labels[aiv1alpha1.LabelMission]).To(Equal(missionName))
+			Expect(missionKnight.Labels[aiv1alpha1.LabelEphemeral]).To(Equal("true"))
+
+			By("Verifying the warm knight was consumed")
+			warmGone := &aiv1alpha1.Knight{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
 				Name:      rtName + "-warm-ready",
 				Namespace: namespace,
-			}, claimedKnight)).To(Succeed())
-
-			Expect(claimedKnight.Labels[aiv1alpha1.LabelWarmPoolClaimed]).To(Equal("true"))
-			Expect(claimedKnight.Labels[aiv1alpha1.LabelMission]).To(Equal(missionName))
+			}, warmGone)
+			Expect(errors.IsNotFound(err)).To(BeTrue(), "warm knight should be deleted after claim")
 
 			By("Verifying mission status shows warm start")
 			mission = &aiv1alpha1.Mission{}
@@ -1820,10 +1839,12 @@ var _ = Describe("Mission Controller - Warm Pool", func() {
 				time.Sleep(100 * time.Millisecond)
 			}
 
-			By("Verifying spec overrides were applied")
+			By("Verifying spec overrides were applied to the mission-prefixed knight")
+			// The claim recreates the knight under "<mission>-<knight>" (the name
+			// chain steps reference); overrides land on that CR.
 			claimedKnight := &aiv1alpha1.Knight{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      rtName + "-warm-override",
+				Name:      missionName + "-knight1",
 				Namespace: namespace,
 			}, claimedKnight)).To(Succeed())
 

--- a/internal/mission/assembler.go
+++ b/internal/mission/assembler.go
@@ -146,12 +146,15 @@ func (a *KnightAssembler) ReconcileAssembling(ctx context.Context, mission *aiv1
 
 			if claimed {
 				log.Info("Claimed warm pool knight for mission", "missionKnight", mk.Name)
-				// Warm knight is already running and ready
+				// The claim recreated the knight under its mission-prefixed name;
+				// wait for the new knight to become ready like a cold start.
 				knightStatuses[mk.Name] = aiv1alpha1.MissionKnightStatus{
 					Name:      mk.Name,
 					Ephemeral: true,
-					Ready:     true,
+					Ready:     false,
 				}
+				allReady = false
+				notReadyKnights = append(notReadyKnights, mk.Name)
 				continue
 			}
 
@@ -251,8 +254,10 @@ func (a *KnightAssembler) ReconcileAssembling(ctx context.Context, mission *aiv1
 }
 
 // claimWarmKnight attempts to claim an available warm pool knight for a mission.
-// It finds an unclaimed, ready warm knight, patches its spec for the mission, and
-// renames it by creating a new knight with the mission name and deleting the warm one.
+// It reserves an unclaimed, ready warm knight, creates the mission knight under
+// its mission-prefixed name ("<mission>-<knight>" — the name chain steps
+// reference), and deletes the warm knight so the pool replenishes. The mission
+// knight starts fresh, so the caller must treat it as not-ready and wait.
 // Returns true if a knight was successfully claimed.
 func (a *KnightAssembler) claimWarmKnight(
 	ctx context.Context,
@@ -301,86 +306,11 @@ func (a *KnightAssembler) claimWarmKnight(
 			"mission", mission.Name,
 			"missionKnight", mk.Name)
 
-		// Resolve the desired spec for this mission knight
-		spec, err := a.resolveKnightSpec(mission, mk, rt)
-		if err != nil {
-			return false, fmt.Errorf("failed to resolve knight spec: %w", err)
-		}
-
-		// Patch the warm knight's spec with mission-specific config
-		natsPrefix := rt.Spec.NATS.SubjectPrefix
-		warmKnight.Spec.Domain = spec.Domain
-		warmKnight.Spec.Model = spec.Model
-		warmKnight.Spec.Skills = spec.Skills
-		warmKnight.Spec.NATS = aiv1alpha1.KnightNATS{
-			URL:           rt.Spec.NATS.URL,
-			Stream:        rt.Spec.NATS.TasksStream,
-			ResultsStream: rt.Spec.NATS.ResultsStream,
-			Subjects: []string{
-				fmt.Sprintf("%s.tasks.%s.>", natsPrefix, spec.Domain),
-			},
-			ConsumerName: fmt.Sprintf("msn-%s-%s", mission.Name, mk.Name),
-			MaxDeliver:   1,
-		}
-		if spec.Prompt != nil {
-			warmKnight.Spec.Prompt = spec.Prompt
-		}
-		if spec.Tools != nil {
-			warmKnight.Spec.Tools = spec.Tools
-		}
-		if spec.Env != nil {
-			warmKnight.Spec.Env = spec.Env
-		}
-		if spec.Concurrency > 0 {
-			warmKnight.Spec.Concurrency = spec.Concurrency
-		}
-		if spec.TaskTimeout > 0 {
-			warmKnight.Spec.TaskTimeout = spec.TaskTimeout
-		}
-		if spec.GeneratedSkills != nil {
-			warmKnight.Spec.GeneratedSkills = spec.GeneratedSkills
-		}
-		if spec.NixPackages != nil {
-			warmKnight.Spec.NixPackages = spec.NixPackages
-		}
-
-		// Inject mission secrets
-		if len(mission.Spec.Secrets) > 0 {
-			for _, secretRef := range mission.Spec.Secrets {
-				warmKnight.Spec.EnvFrom = append(warmKnight.Spec.EnvFrom, corev1.EnvFromSource{
-					SecretRef: &corev1.SecretEnvSource{
-						LocalObjectReference: secretRef,
-					},
-				})
-			}
-		}
-
-		// Use mission-scoped ServiceAccount
-		warmKnight.Spec.ServiceAccountName = fmt.Sprintf("mission-%s", mission.Name)
-
-		// Update labels: mark as claimed, link to mission
+		// Reserve the warm knight: mark as claimed and link to the mission.
+		// The knight is replaced (not patched) below — chain steps reference the
+		// mission-prefixed name, and CR names are immutable.
 		warmKnight.Labels[aiv1alpha1.LabelWarmPoolClaimed] = "true"
 		warmKnight.Labels[aiv1alpha1.LabelMission] = mission.Name
-		warmKnight.Labels[aiv1alpha1.LabelEphemeral] = "true"
-		if mk.Role != "" {
-			sanitized := sanitizeLabelValue(mk.Role)
-			if sanitized != "" {
-				warmKnight.Labels[aiv1alpha1.LabelRole] = sanitized
-			}
-		}
-
-		// Add mission as a NON-CONTROLLER owner reference.
-		// RoundTable is already the controller owner — only one controller is allowed.
-		warmKnight.OwnerReferences = append(warmKnight.OwnerReferences,
-			metav1.OwnerReference{
-				APIVersion:         aiv1alpha1.GroupVersion.String(),
-				Kind:               "Mission",
-				Name:               mission.Name,
-				UID:                mission.UID,
-				Controller:         ptrBool(false),
-				BlockOwnerDeletion: ptrBool(true),
-			},
-		)
 
 		// Attempt update — resourceVersion provides optimistic locking.
 		// If another mission claimed this knight, we get a Conflict and try the next candidate.
@@ -396,10 +326,30 @@ func (a *KnightAssembler) claimWarmKnight(
 		// Mark as claimed in this cycle to avoid double-claiming
 		alreadyClaimed[warmKnight.Name] = true
 
+		// Create the mission knight under its prefixed name so chain steps
+		// (which reference "<mission>-<knight>") resolve to a real CR.
+		missionKnight, err := a.buildEphemeralKnight(ctx, mission, mk, rt)
+		if err != nil {
+			return false, fmt.Errorf("failed to build mission knight for warm claim: %w", err)
+		}
+		if err := a.Client.Create(ctx, missionKnight); err != nil && !apierrors.IsAlreadyExists(err) {
+			// Warm knight stays reserved; the caller falls back to cold start,
+			// which retries the same create on the next reconcile.
+			return false, fmt.Errorf("failed to create mission knight %q from warm claim: %w", missionKnight.Name, err)
+		}
+
+		// Delete the warm knight — its capacity is consumed by the mission knight,
+		// and the RoundTable controller will replenish the pool.
+		if err := a.Client.Delete(ctx, warmKnight); err != nil && !apierrors.IsNotFound(err) {
+			log.Error(err, "Failed to delete claimed warm knight; pool controller will reap it",
+				"warmKnight", warmKnight.Name)
+		}
+
 		log.Info("Successfully claimed warm pool knight",
 			"warmKnight", warmKnight.Name,
+			"missionKnight", missionKnight.Name,
 			"mission", mission.Name,
-			"domain", spec.Domain)
+			"domain", missionKnight.Spec.Domain)
 
 		return true, nil
 	}
@@ -836,9 +786,4 @@ func sanitizeLabelValue(s string) string {
 
 func isAlphanumeric(c byte) bool {
 	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
-}
-
-// ptrBool returns a pointer to a bool value.
-func ptrBool(b bool) *bool {
-	return &b
 }

--- a/internal/mission/planner.go
+++ b/internal/mission/planner.go
@@ -233,15 +233,6 @@ func (p *Planner) ReconcilePlanning(ctx context.Context, mission *aiv1alpha1.Mis
 	pr.SkillsGenerated = int32(len(plan.Skills))
 	pr.RawOutput = util.Truncate(output, 10000)
 
-	// Bug #85: Set PlanApplied condition to prevent duplicate applications on retry
-	meta.SetStatusCondition(&mission.Status.Conditions, metav1.Condition{
-		Type:               "PlanApplied",
-		Status:             metav1.ConditionTrue,
-		Reason:             "PlanningComplete",
-		Message:            fmt.Sprintf("Generated %d chains, %d knights, %d skills", pr.ChainsGenerated, pr.KnightsGenerated, pr.SkillsGenerated),
-		ObservedGeneration: mission.Generation,
-	})
-
 	log.Info("Planning completed successfully",
 		"chains", pr.ChainsGenerated,
 		"knights", pr.KnightsGenerated,
@@ -255,6 +246,21 @@ func (p *Planner) ReconcilePlanning(ctx context.Context, mission *aiv1alpha1.Mis
 	if err := p.Client.Update(ctx, mission); err != nil {
 		return ctrl.Result{}, err
 	}
+
+	// The spec update decoded the server response into `mission`, replacing
+	// Status with the server's copy (spec updates ignore status) — restore the
+	// completed planning result before persisting status, or the counters and
+	// CompletedAt are silently lost.
+	mission.Status.PlanningResult = pr
+
+	// Bug #85: Set PlanApplied condition to prevent duplicate applications on retry
+	meta.SetStatusCondition(&mission.Status.Conditions, metav1.Condition{
+		Type:               "PlanApplied",
+		Status:             metav1.ConditionTrue,
+		Reason:             "PlanningComplete",
+		Message:            fmt.Sprintf("Generated %d chains, %d knights, %d skills", pr.ChainsGenerated, pr.KnightsGenerated, pr.SkillsGenerated),
+		ObservedGeneration: mission.Generation,
+	})
 
 	// Transition to Assembling phase with the PlanApplied condition in one update
 	mission.Status.Phase = aiv1alpha1.MissionPhaseAssembling


### PR DESCRIPTION
Fixes the two operator-side bugs found during the live 0.12.3 dashboard verification (mission `live-test-fable`):

**1. Meta-missions fail with `InvalidKnightRef` when a warm-pool knight is claimed**
Chain steps are prefixed to `<mission>-<knight>` (planner.go) and cold starts create that CR (assembler.go), but `claimWarmKnight` patched the warm knight in place, keeping its `<rt>-warm-<hex>` name — the referenced CR never existed and chain validation failed permanently. The doc comment always promised a rename; CR names are immutable, so the claim now: reserve warm knight (existing optimistic-lock update) → create the mission knight under its prefixed name → delete the warm knight (pool replenishes). The in-place spec patch changed model/skills/NATS and forced a pod rollout anyway, so no real warmth is lost. Caller now waits for the recreated knight like a cold start.

**2. `planningResult` reports 0 chains/knights/skills with empty completedAt**
Counters, CompletedAt, and the PlanApplied condition were written to `mission.Status` *before* the spec `Update()` — whose response overwrites local Status with the server's stale copy — so `Status().Update()` persisted zeros (exactly what `/api/missions` showed live). The planning result and condition are now restored after the spec update.

Tests: warm-claim tests updated to assert the new contract (prefixed CR exists, warm knight consumed, spec overrides land on the prefixed CR). `mise run operator:test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)