### PR TITLE
fix: preserve mission terminal outcome through cleanup

### DIFF
--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -156,6 +156,10 @@ const (
 	// ReasonMissionChainFailed indicates one or more mission chains failed.
 	ReasonMissionChainFailed = "ChainFailed"
 
+	// ReasonMissionFailed indicates the mission failed before its chains could
+	// complete (e.g. assembly timeout or planning failure).
+	ReasonMissionFailed = "Failed"
+
 	// ReasonMissionTimeout indicates the mission exceeded its timeout.
 	ReasonMissionTimeout = "Timeout"
 

--- a/internal/controller/mission_controller.go
+++ b/internal/controller/mission_controller.go
@@ -165,6 +165,26 @@ func (r *MissionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if meta.IsStatusConditionTrue(mission.Status.Conditions, aiv1alpha1.ConditionCleanupComplete) {
 			return ctrl.Result{}, nil
 		}
+		// Record the outcome in the Complete condition before overwriting the
+		// phase — paths like the assembly timeout set Failed without one, and
+		// cleanup needs it to restore the right terminal phase afterwards.
+		if !meta.IsStatusConditionTrue(mission.Status.Conditions, aiv1alpha1.ConditionMissionComplete) {
+			reason := aiv1alpha1.ReasonMissionSucceeded
+			if mission.Status.Phase == aiv1alpha1.MissionPhaseFailed {
+				reason = aiv1alpha1.ReasonMissionFailed
+			}
+			message := mission.Status.Result
+			if message == "" {
+				message = fmt.Sprintf("Mission %s", mission.Status.Phase)
+			}
+			meta.SetStatusCondition(&mission.Status.Conditions, metav1.Condition{
+				Type:               aiv1alpha1.ConditionMissionComplete,
+				Status:             metav1.ConditionTrue,
+				Reason:             reason,
+				Message:            message,
+				ObservedGeneration: mission.Generation,
+			})
+		}
 		mission.Status.Phase = aiv1alpha1.MissionPhaseCleaningUp
 		mission.Status.ObservedGeneration = mission.Generation
 		err := r.Status().Update(ctx, mission)
@@ -824,29 +844,7 @@ func (r *MissionReconciler) transitionToTerminalPhase(ctx context.Context, missi
 	log := logf.FromContext(ctx)
 
 	// Transition to terminal phase based on original outcome
-	if mission.Status.Phase != aiv1alpha1.MissionPhaseSucceeded &&
-		mission.Status.Phase != aiv1alpha1.MissionPhaseFailed &&
-		mission.Status.Phase != aiv1alpha1.MissionPhaseExpired {
-		// Determine terminal phase from chain results and planning outcome
-		allSucceeded := true
-
-		// Check if planning failed
-		if mission.Status.Result != "" && strings.Contains(mission.Status.Result, "failed") {
-			allSucceeded = false
-		}
-
-		for _, cs := range mission.Status.ChainStatuses {
-			if cs.Phase == aiv1alpha1.ChainPhaseFailed {
-				allSucceeded = false
-				break
-			}
-		}
-		if allSucceeded {
-			mission.Status.Phase = aiv1alpha1.MissionPhaseSucceeded
-		} else {
-			mission.Status.Phase = aiv1alpha1.MissionPhaseFailed
-		}
-	}
+	mission.Status.Phase = terminalOutcome(mission)
 
 	mission.Status.ObservedGeneration = mission.Generation
 	if err := r.Status().Update(ctx, mission); err != nil {
@@ -1311,6 +1309,40 @@ func (r *MissionReconciler) updateChainStatus(mission *aiv1alpha1.Mission, chain
 	})
 }
 
+// terminalOutcome returns the mission's terminal phase. The phase itself is
+// overwritten to CleaningUp while cleanup runs, so the outcome is read from
+// the Complete condition (recorded before cleanup starts); missions that
+// reach cleanup without one fall back to inferring from result and chains.
+func terminalOutcome(mission *aiv1alpha1.Mission) aiv1alpha1.MissionPhase {
+	switch mission.Status.Phase {
+	case aiv1alpha1.MissionPhaseSucceeded, aiv1alpha1.MissionPhaseFailed, aiv1alpha1.MissionPhaseExpired:
+		return mission.Status.Phase
+	}
+
+	if cond := meta.FindStatusCondition(mission.Status.Conditions, aiv1alpha1.ConditionMissionComplete); cond != nil &&
+		cond.Status == metav1.ConditionTrue {
+		switch cond.Reason {
+		case aiv1alpha1.ReasonMissionSucceeded:
+			return aiv1alpha1.MissionPhaseSucceeded
+		case aiv1alpha1.ReasonMissionExpired:
+			return aiv1alpha1.MissionPhaseExpired
+		default: // Failed, ChainFailed, Timeout, OverBudget, ...
+			return aiv1alpha1.MissionPhaseFailed
+		}
+	}
+
+	// Legacy inference for missions completed before the condition was recorded.
+	if mission.Status.Result != "" && strings.Contains(mission.Status.Result, "failed") {
+		return aiv1alpha1.MissionPhaseFailed
+	}
+	for _, cs := range mission.Status.ChainStatuses {
+		if cs.Phase == aiv1alpha1.ChainPhaseFailed {
+			return aiv1alpha1.MissionPhaseFailed
+		}
+	}
+	return aiv1alpha1.MissionPhaseSucceeded
+}
+
 // shouldDeleteResources determines if resources should be deleted based on cleanup policy and mission outcome.
 func (r *MissionReconciler) shouldDeleteResources(mission *aiv1alpha1.Mission) bool {
 	switch mission.Spec.CleanupPolicy {
@@ -1319,9 +1351,9 @@ func (r *MissionReconciler) shouldDeleteResources(mission *aiv1alpha1.Mission) b
 	case "Retain":
 		return false
 	case "OnSuccess":
-		return mission.Status.Phase == aiv1alpha1.MissionPhaseSucceeded
+		return terminalOutcome(mission) == aiv1alpha1.MissionPhaseSucceeded
 	case "OnFailure":
-		return mission.Status.Phase == aiv1alpha1.MissionPhaseFailed
+		return terminalOutcome(mission) == aiv1alpha1.MissionPhaseFailed
 	default:
 		return true // Default to Delete
 	}

--- a/internal/controller/mission_controller_test.go
+++ b/internal/controller/mission_controller_test.go
@@ -856,6 +856,36 @@ var _ = Describe("Mission Controller", func() {
 			Expect(condition).NotTo(BeNil())
 			Expect(condition.Status).To(Equal(metav1.ConditionTrue))
 		})
+
+		It("should keep a Failed phase through cleanup", func() {
+			r := newReconciler()
+
+			driveToPhase(r, aiv1alpha1.MissionPhaseActive, 10, readyOnProvisioning(), readyOnAssembling())
+
+			// Fail the mission the way the assembly timeout does: phase Failed
+			// with a result message, but no Complete condition. The result
+			// deliberately doesn't contain "failed" — the old inference marked
+			// exactly this case Succeeded after cleanup.
+			mission := &aiv1alpha1.Mission{}
+			Expect(k8sClient.Get(ctx, missionNN, mission)).To(Succeed())
+			mission.Status.Phase = aiv1alpha1.MissionPhaseFailed
+			mission.Status.Result = "Assembly timeout: knights not ready: [tester]"
+			Expect(k8sClient.Status().Update(ctx, mission)).To(Succeed())
+
+			// First reconcile: Failed -> CleaningUp (records the outcome),
+			// second: runs cleanup and restores the terminal phase.
+			_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: missionNN})
+			_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: missionNN})
+
+			mission = &aiv1alpha1.Mission{}
+			Expect(k8sClient.Get(ctx, missionNN, mission)).To(Succeed())
+			Expect(mission.Status.Phase).To(Equal(aiv1alpha1.MissionPhaseFailed))
+			Expect(mission.Status.Result).To(ContainSubstring("Assembly timeout"))
+
+			condition := meta.FindStatusCondition(mission.Status.Conditions, aiv1alpha1.ConditionMissionComplete)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Reason).To(Equal(aiv1alpha1.ReasonMissionFailed))
+		})
 	})
 
 	Context("Knight Templates", func() {

--- a/internal/mission/assembler.go
+++ b/internal/mission/assembler.go
@@ -28,6 +28,12 @@ type KnightAssembler struct {
 	Scheme *runtime.Scheme
 }
 
+// minAssemblyTimeout floors the assembly window. Ephemeral knights always
+// start cold (PVC provisioning, Nix tool builds, image pulls), which
+// legitimately takes a couple of minutes — a short mission timeout must not
+// fail assembly before the pod has a chance to become ready.
+const minAssemblyTimeout = 3 * time.Minute
+
 // ReconcileAssembling handles the Assembling phase - creates ephemeral knights and waits for readiness.
 func (a *KnightAssembler) ReconcileAssembling(ctx context.Context, mission *aiv1alpha1.Mission) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
@@ -204,8 +210,11 @@ func (a *KnightAssembler) ReconcileAssembling(ctx context.Context, mission *aiv1
 
 	// Note: Caller should update status
 
-	// Check assembly timeout (Timeout/3)
+	// Check assembly timeout (Timeout/3, floored at minAssemblyTimeout)
 	assemblyTimeout := time.Duration(mission.Spec.Timeout/3) * time.Second
+	if assemblyTimeout < minAssemblyTimeout {
+		assemblyTimeout = minAssemblyTimeout
+	}
 	if mission.Status.StartedAt != nil && time.Since(mission.Status.StartedAt.Time) > assemblyTimeout {
 		log.Info("Assembly timeout exceeded",
 			"timeout", assemblyTimeout,

--- a/internal/mission/planner_applyplan_test.go
+++ b/internal/mission/planner_applyplan_test.go
@@ -1,0 +1,83 @@
+package mission
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	aiv1alpha1 "github.com/dapperdivers/roundtable/api/v1alpha1"
+)
+
+// TestApplyPlanKnightRefPrefixing covers the fix for the InvalidKnightRef bug:
+// ephemeral knights are created as "<mission>-<knight>", so chain steps that
+// reference them by plan name must be prefixed the same way. Non-ephemeral
+// (recruited) knights keep their bare names.
+func TestApplyPlanKnightRefPrefixing(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add client-go scheme: %v", err)
+	}
+	if err := aiv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add roundtable scheme: %v", err)
+	}
+
+	mission := &aiv1alpha1.Mission{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-mission",
+			Namespace: "default",
+		},
+		Spec: aiv1alpha1.MissionSpec{
+			Objective:     "test",
+			RoundTableRef: "personal",
+		},
+	}
+
+	plan := &PlannerOutput{
+		PlanVersion: "v1alpha1",
+		Knights: []PlannerKnight{
+			{Name: "haiku-writer", Ephemeral: true, TemplateRef: "base"},
+			{Name: "standing-knight", Ephemeral: false},
+		},
+		Chains: []PlannerChain{
+			{
+				Name: "haiku-creation",
+				Steps: []aiv1alpha1.ChainStep{
+					{Name: "write", KnightRef: "haiku-writer", Task: "write it"},
+					{Name: "review", KnightRef: "standing-knight", Task: "review it", DependsOn: []string{"write"}},
+				},
+			},
+		},
+	}
+
+	p := &Planner{Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+	if err := p.applyPlan(context.Background(), mission, plan); err != nil {
+		t.Fatalf("applyPlan failed: %v", err)
+	}
+
+	if len(mission.Spec.GeneratedChains) != 1 {
+		t.Fatalf("expected 1 generated chain, got %d", len(mission.Spec.GeneratedChains))
+	}
+	steps := mission.Spec.GeneratedChains[0].Steps
+	if got, want := steps[0].KnightRef, "test-mission-haiku-writer"; got != want {
+		t.Errorf("ephemeral knightRef = %q, want %q (mission-prefixed)", got, want)
+	}
+	if got, want := steps[1].KnightRef, "standing-knight"; got != want {
+		t.Errorf("recruited knightRef = %q, want %q (unprefixed)", got, want)
+	}
+
+	// The created Chain CR must carry the same prefixed refs — this is what
+	// the chain controller resolves against real Knight CRs.
+	chain := &aiv1alpha1.Chain{}
+	chainKey := types.NamespacedName{Name: "mission-test-mission-haiku-creation", Namespace: "default"}
+	if err := p.Client.Get(context.Background(), chainKey, chain); err != nil {
+		t.Fatalf("expected chain CR to be created: %v", err)
+	}
+	if got, want := chain.Spec.Steps[0].KnightRef, "test-mission-haiku-writer"; got != want {
+		t.Errorf("chain CR ephemeral knightRef = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## What

Post-deploy verification of #136 (2026-07-04) surfaced a new operator bug: a meta-mission whose knight missed the assembly window ended with **phase Succeeded** while \`status.result\` said \`Assembly timeout: knights not ready\` — events show the mission did transition to Failed, then cleanup flipped it.

### Root cause

Entering CleaningUp overwrites the terminal phase, and \`transitionToTerminalPhase\` re-inferred the outcome afterwards from \`strings.Contains(status.result, "failed")\` + chain statuses. An assembly timeout's result has no "failed" substring and no chains ever ran, so the mission was inferred successful.

### Changes

- Record the outcome in the \`Complete\` condition before entering CleaningUp (assembly-timeout/planning-failure paths set the phase directly without one; normal completion paths already set it).
- After cleanup, restore the terminal phase from that condition (\`Succeeded\`/\`Expired\`/anything-else→\`Failed\`); the old substring inference remains only as a fallback. Expired missions now end \`Expired\` instead of being re-inferred as \`Succeeded\`.
- \`shouldDeleteResources\`: \`OnSuccess\`/\`OnFailure\` compared against the phase, which is always \`CleaningUp\` during cleanup — neither policy could ever match. Now uses the recorded outcome.
- Floor the assembly window at 3 minutes. It was \`Timeout/3\` with no floor; the dashboard wizard defaults \`timeout: 300\` → a 100s window, while post-#136 every ephemeral knight cold-starts through PVC provisioning + a Nix tools build (~30s+ on a healthy node). This is what failed the verification mission.
- Add the missing \`applyPlan\` unit test for ephemeral knightRef prefixing (the test gap that let the original InvalidKnightRef bug through).

## Testing

- New envtest case: mission Failed with an assembly-timeout result (no Complete condition) keeps phase Failed through cleanup — reproduces the live bug, fails on main.
- New unit test: \`TestApplyPlanKnightRefPrefixing\` (ephemeral refs prefixed, recruited refs untouched, chain CR carries prefixed refs).
- \`make test\` green across the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)