### PR TITLE
fix: stop chain reconcile noise after mission cleanup

### DIFF
--- a/internal/controller/chain_controller.go
+++ b/internal/controller/chain_controller.go
@@ -83,6 +83,7 @@ func (r *ChainReconciler) natsClient() (natspkg.Client, error) {
 // +kubebuilder:rbac:groups=ai.roundtable.io,resources=chains/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=ai.roundtable.io,resources=chains/finalizers,verbs=update
 // +kubebuilder:rbac:groups=ai.roundtable.io,resources=knights,verbs=get;list;watch
+// +kubebuilder:rbac:groups=ai.roundtable.io,resources=missions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=ai.roundtable.io,resources=roundtables,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
@@ -136,6 +137,17 @@ func (r *ChainReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	// Validate knight refs
 	if err := r.validateKnightRefs(ctx, chain); err != nil {
+		// A knight that disappears after the owning mission started cleanup
+		// (or is gone / terminal) was deleted BY that cleanup — mission-scoped
+		// ephemeral knights are removed before the chain itself is
+		// garbage-collected. Reporting InvalidKnightRef then is post-cleanup
+		// noise that looks like the dispatch failure cause, so stop
+		// reconciling quietly instead of setting conditions and requeuing.
+		if apierrors.IsNotFound(err) && r.owningMissionInactive(ctx, chain) {
+			log.V(1).Info("Knight missing after owning mission cleanup, stopping reconcile",
+				"mission", chain.Labels[aiv1alpha1.LabelMission])
+			return ctrl.Result{}, nil
+		}
 		meta.SetStatusCondition(&chain.Status.Conditions, metav1.Condition{
 			Type:               aiv1alpha1.ConditionChainValid,
 			Status:             metav1.ConditionFalse,
@@ -275,6 +287,36 @@ func (r *ChainReconciler) validateKnightRefs(ctx context.Context, chain *aiv1alp
 		}
 	}
 	return nil
+}
+
+// owningMissionInactive reports whether the chain belongs to a mission that no
+// longer needs it reconciled: the mission is gone, being deleted, cleaning up,
+// or already in a terminal phase (Succeeded/Failed/Expired). Mission cleanup
+// deletes the mission's ephemeral knights before the chain is garbage-collected,
+// so a chain can transiently reference knights that were legitimately removed.
+// A missing knight while the mission is still active (pre-dispatch) is a real
+// error and is NOT covered here.
+func (r *ChainReconciler) owningMissionInactive(ctx context.Context, chain *aiv1alpha1.Chain) bool {
+	missionName := chain.Labels[aiv1alpha1.LabelMission]
+	if missionName == "" {
+		return false
+	}
+	mission := &aiv1alpha1.Mission{}
+	if err := r.Get(ctx, types.NamespacedName{Name: missionName, Namespace: chain.Namespace}, mission); err != nil {
+		// Mission deleted entirely — the chain is an orphan awaiting GC.
+		return apierrors.IsNotFound(err)
+	}
+	if mission.DeletionTimestamp != nil {
+		return true
+	}
+	switch mission.Status.Phase {
+	case aiv1alpha1.MissionPhaseCleaningUp,
+		aiv1alpha1.MissionPhaseSucceeded,
+		aiv1alpha1.MissionPhaseFailed,
+		aiv1alpha1.MissionPhaseExpired:
+		return true
+	}
+	return false
 }
 
 // validateDAG performs topological sort to detect cycles.

--- a/internal/controller/chain_controller_test.go
+++ b/internal/controller/chain_controller_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -323,6 +324,128 @@ var _ = Describe("Chain Controller", func() {
 				NamespacedName: types.NamespacedName{Name: "nonexistent", Namespace: namespace},
 			})
 			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("Mission cleanup noise suppression", func() {
+		const missionName = "meta-mission"
+		missionNN := types.NamespacedName{Name: missionName, Namespace: namespace}
+
+		// A mission-scoped chain whose step references an ephemeral knight
+		// that no longer exists (deleted by mission cleanup).
+		makeMissionChain := func() *aiv1alpha1.Chain {
+			return &aiv1alpha1.Chain{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      chainName,
+					Namespace: namespace,
+					Labels:    map[string]string{aiv1alpha1.LabelMission: missionName},
+				},
+				Spec: aiv1alpha1.ChainSpec{
+					RoundTableRef: roundTableName,
+					Steps: []aiv1alpha1.ChainStep{
+						{Name: "scan", KnightRef: "mission-" + missionName + "-ghost", Task: "scan"},
+					},
+					Timeout: 600,
+				},
+			}
+		}
+
+		createMission := func(phase aiv1alpha1.MissionPhase) {
+			mission := &aiv1alpha1.Mission{
+				ObjectMeta: metav1.ObjectMeta{Name: missionName, Namespace: namespace},
+				Spec:       aiv1alpha1.MissionSpec{Objective: "test objective"},
+			}
+			Expect(k8sClient.Create(ctx, mission)).To(Succeed())
+			if phase != "" {
+				mission.Status.Phase = phase
+				Expect(k8sClient.Status().Update(ctx, mission)).To(Succeed())
+			}
+		}
+
+		// First reconcile adds the finalizer (and already runs validation);
+		// the second is the steady-state pass whose outcome we assert on.
+		reconcileTwice := func(r *ChainReconciler) (reconcile.Result, error) {
+			_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: chainNN})
+			return r.Reconcile(ctx, reconcile.Request{NamespacedName: chainNN})
+		}
+
+		BeforeEach(func() {
+			ensureRoundTable()
+		})
+
+		AfterEach(func() {
+			chain := &aiv1alpha1.Chain{}
+			if err := k8sClient.Get(ctx, chainNN, chain); err == nil {
+				chain.Finalizers = nil
+				_ = k8sClient.Update(ctx, chain)
+				k8sClient.Delete(ctx, chain)
+			}
+			mission := &aiv1alpha1.Mission{}
+			if err := k8sClient.Get(ctx, missionNN, mission); err == nil {
+				k8sClient.Delete(ctx, mission)
+			}
+		})
+
+		It("should stop quietly when the knight is missing and the mission is CleaningUp", func() {
+			createMission(aiv1alpha1.MissionPhaseCleaningUp)
+			Expect(k8sClient.Create(ctx, makeMissionChain())).To(Succeed())
+
+			r := newReconciler()
+			result, err := reconcileTwice(r)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			updated := &aiv1alpha1.Chain{}
+			Expect(k8sClient.Get(ctx, chainNN, updated)).To(Succeed())
+			Expect(apimeta.FindStatusCondition(updated.Status.Conditions, aiv1alpha1.ConditionChainValid)).To(BeNil())
+		})
+
+		It("should stop quietly when the knight is missing and the mission is terminal", func() {
+			createMission(aiv1alpha1.MissionPhaseFailed)
+			Expect(k8sClient.Create(ctx, makeMissionChain())).To(Succeed())
+
+			r := newReconciler()
+			result, err := reconcileTwice(r)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			updated := &aiv1alpha1.Chain{}
+			Expect(k8sClient.Get(ctx, chainNN, updated)).To(Succeed())
+			Expect(apimeta.FindStatusCondition(updated.Status.Conditions, aiv1alpha1.ConditionChainValid)).To(BeNil())
+		})
+
+		It("should stop quietly when the knight is missing and the mission is gone", func() {
+			// No mission created — it was deleted entirely.
+			Expect(k8sClient.Create(ctx, makeMissionChain())).To(Succeed())
+
+			r := newReconciler()
+			result, err := reconcileTwice(r)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			updated := &aiv1alpha1.Chain{}
+			Expect(k8sClient.Get(ctx, chainNN, updated)).To(Succeed())
+			Expect(apimeta.FindStatusCondition(updated.Status.Conditions, aiv1alpha1.ConditionChainValid)).To(BeNil())
+		})
+
+		It("should still report InvalidKnightRef while the mission is active", func() {
+			// Pre-dispatch: a missing knight while the mission is still
+			// assembling is a real error and must keep being reported
+			// (regression guard for the #136 class of bugs).
+			createMission(aiv1alpha1.MissionPhaseAssembling)
+			Expect(k8sClient.Create(ctx, makeMissionChain())).To(Succeed())
+
+			r := newReconciler()
+			_, err := reconcileTwice(r)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("non-existent knight"))
+
+			updated := &aiv1alpha1.Chain{}
+			Expect(k8sClient.Get(ctx, chainNN, updated)).To(Succeed())
+			cond := apimeta.FindStatusCondition(updated.Status.Conditions, aiv1alpha1.ConditionChainValid)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal(aiv1alpha1.ReasonInvalidKnightRef))
 		})
 	})
 


### PR DESCRIPTION
## The noise mechanism

When a meta-mission's chain step fails, the mission enters cleanup and deletes its ephemeral (mission-prefixed) knights immediately. The chain CR outlives them briefly (until GC via the mission owner ref), and the chain controller re-validates `knightRefs` on **every** reconcile — before the phase switch, so even a chain already in a terminal phase re-validates. Each pass after cleanup therefore:

1. found the knight gone (`validateKnightRefs` → NotFound),
2. set `ChainValid=False` / `InvalidKnightRef` on the chain,
3. returned the error to controller-runtime → endless backoff-requeue loop.

The resulting conditions/logs looked like the *cause* of the dispatch failure when they were actually an artifact of cleanup, polluting events and misleading debugging.

## The guard

In the `validateKnightRefs` failure branch of `ChainReconciler.Reconcile`: if the error is `NotFound` **and** the owning mission (resolved via the `ai.roundtable.io/mission` label) is

- in phase `CleaningUp`, `Succeeded`, `Failed`, or `Expired`,
- being deleted (`DeletionTimestamp` set), or
- gone entirely (NotFound),

then log at V(1) and return `ctrl.Result{}, nil` — no condition, no event, no requeue. Chains without the mission label are unaffected. Chain deletion itself was already handled earlier in reconcile.

## What still fires (regression guard for #136/#137 interactions)

A knight missing while the mission is still **active** (Pending/Provisioning/Planning/Assembling/Briefing/Active) is a real pre-dispatch error and keeps being reported exactly as before — that is the window where the #136 knightRef-prefixing class of bugs must stay detectable. The guard is also gated on `NotFound`, so any other API error from knight lookup still surfaces. Mission phase detection relies on the phase value only; it works with or without the #137 `Complete` condition.

## Tests

New envtest cases in `internal/controller/chain_controller_test.go` ("Mission cleanup noise suppression"):
- knight missing + mission `CleaningUp` → no error, no requeue, no `ChainValid` condition
- knight missing + mission terminal (`Failed`) → same
- knight missing + mission deleted entirely → same
- knight missing + mission `Assembling` → `InvalidKnightRef` condition and error still reported

`mise run operator:test` (full suite incl. envtest) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)