### PR TITLE
feat: default bare Knights to the cheap OpenRouter model

### DIFF
--- a/api/v1alpha1/knight_types.go
+++ b/api/v1alpha1/knight_types.go
@@ -62,8 +62,8 @@ type KnightSpec struct {
 	// +kubebuilder:validation:MinLength=1
 	Domain string `json:"domain"`
 
-	// model is the AI model to use (e.g., "claude-sonnet-4-20250514", "claude-haiku-35-20241022").
-	// +kubebuilder:default="claude-sonnet-4-20250514"
+	// model is the AI model to use (e.g., "openrouter/deepseek/deepseek-v3.2", "claude-sonnet-4-20250514").
+	// +kubebuilder:default="openrouter/deepseek/deepseek-v3.2"
 	// +optional
 	Model string `json:"model,omitempty"`
 

--- a/charts/roundtable-operator/Chart.yaml
+++ b/charts/roundtable-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: roundtable-operator
 description: Knights of the Round Table — A Kubernetes Operator for Multi-Agent AI Orchestration
 type: application
-version: 0.12.3
+version: 0.13.0
 appVersion: "1.0.0"
 keywords:
   - ai

--- a/charts/roundtable-operator/crds/ai.roundtable.io_knights.yaml
+++ b/charts/roundtable-operator/crds/ai.roundtable.io_knights.yaml
@@ -361,9 +361,9 @@ spec:
                     type: string
                 type: object
               model:
-                default: claude-sonnet-4-20250514
-                description: model is the AI model to use (e.g., "claude-sonnet-4-20250514",
-                  "claude-haiku-35-20241022").
+                default: openrouter/deepseek/deepseek-v3.2
+                description: model is the AI model to use (e.g., "openrouter/deepseek/deepseek-v3.2",
+                  "claude-sonnet-4-20250514").
                 type: string
               nats:
                 description: nats configures the knight's NATS JetStream consumer

--- a/charts/roundtable-operator/crds/ai.roundtable.io_missions.yaml
+++ b/charts/roundtable-operator/crds/ai.roundtable.io_missions.yaml
@@ -560,9 +560,9 @@ spec:
                               type: string
                           type: object
                         model:
-                          default: claude-sonnet-4-20250514
-                          description: model is the AI model to use (e.g., "claude-sonnet-4-20250514",
-                            "claude-haiku-35-20241022").
+                          default: openrouter/deepseek/deepseek-v3.2
+                          description: model is the AI model to use (e.g., "openrouter/deepseek/deepseek-v3.2",
+                            "claude-sonnet-4-20250514").
                           type: string
                         nats:
                           description: nats configures the knight's NATS JetStream
@@ -1332,9 +1332,9 @@ spec:
                               type: string
                           type: object
                         model:
-                          default: claude-sonnet-4-20250514
-                          description: model is the AI model to use (e.g., "claude-sonnet-4-20250514",
-                            "claude-haiku-35-20241022").
+                          default: openrouter/deepseek/deepseek-v3.2
+                          description: model is the AI model to use (e.g., "openrouter/deepseek/deepseek-v3.2",
+                            "claude-sonnet-4-20250514").
                           type: string
                         nats:
                           description: nats configures the knight's NATS JetStream
@@ -1863,9 +1863,9 @@ spec:
                               type: string
                           type: object
                         model:
-                          default: claude-sonnet-4-20250514
-                          description: model is the AI model to use (e.g., "claude-sonnet-4-20250514",
-                            "claude-haiku-35-20241022").
+                          default: openrouter/deepseek/deepseek-v3.2
+                          description: model is the AI model to use (e.g., "openrouter/deepseek/deepseek-v3.2",
+                            "claude-sonnet-4-20250514").
                           type: string
                         nats:
                           description: nats configures the knight's NATS JetStream
@@ -2654,9 +2654,9 @@ spec:
                             type: string
                         type: object
                       model:
-                        default: claude-sonnet-4-20250514
-                        description: model is the AI model to use (e.g., "claude-sonnet-4-20250514",
-                          "claude-haiku-35-20241022").
+                        default: openrouter/deepseek/deepseek-v3.2
+                        description: model is the AI model to use (e.g., "openrouter/deepseek/deepseek-v3.2",
+                          "claude-sonnet-4-20250514").
                         type: string
                       nats:
                         description: nats configures the knight's NATS JetStream consumer

--- a/charts/roundtable-operator/crds/ai.roundtable.io_roundtables.yaml
+++ b/charts/roundtable-operator/crds/ai.roundtable.io_roundtables.yaml
@@ -492,9 +492,9 @@ spec:
                           type: string
                       type: object
                     model:
-                      default: claude-sonnet-4-20250514
-                      description: model is the AI model to use (e.g., "claude-sonnet-4-20250514",
-                        "claude-haiku-35-20241022").
+                      default: openrouter/deepseek/deepseek-v3.2
+                      description: model is the AI model to use (e.g., "openrouter/deepseek/deepseek-v3.2",
+                        "claude-sonnet-4-20250514").
                       type: string
                     nats:
                       description: nats configures the knight's NATS JetStream consumer
@@ -1179,9 +1179,9 @@ spec:
                             type: string
                         type: object
                       model:
-                        default: claude-sonnet-4-20250514
-                        description: model is the AI model to use (e.g., "claude-sonnet-4-20250514",
-                          "claude-haiku-35-20241022").
+                        default: openrouter/deepseek/deepseek-v3.2
+                        description: model is the AI model to use (e.g., "openrouter/deepseek/deepseek-v3.2",
+                          "claude-sonnet-4-20250514").
                         type: string
                       nats:
                         description: nats configures the knight's NATS JetStream consumer

--- a/charts/roundtable-operator/values.yaml
+++ b/charts/roundtable-operator/values.yaml
@@ -113,7 +113,7 @@ dashboard:
 # knights:
 #   galahad:
 #     domain: security
-#     model: claude-sonnet-4-20250514
+#     model: openrouter/deepseek/deepseek-v3.2
 #     skills: [security, opencti, shared]
 #     tools:
 #       apt: [nmap, whois, dnsutils]

--- a/charts/roundtable-operator/values.yaml
+++ b/charts/roundtable-operator/values.yaml
@@ -36,10 +36,10 @@ extraArgs: []
 images:
   piKnight:
     repository: ghcr.io/dapperdivers/pi-knight
-    tag: 7abd75f6ce2141cf554a9be97ef79f05f4fd0336
+    tag: fb42daedc97e845b049a2855a78d731b125d80d9
   dashboard:
     repository: ghcr.io/dapperdivers/roundtable-ui
-    tag: f7fccb6d2318eca1250f0655a53a4f67a4855415
+    tag: 630f8dfc80532139211896a67f3c9635aa0928b0
 
 # Pod-level security context for all knight-owned pods — knight Deployments
 # AND the shared Nix store build Jobs. Set once here; the operator applies it

--- a/config/crd/bases/ai.roundtable.io_knights.yaml
+++ b/config/crd/bases/ai.roundtable.io_knights.yaml
@@ -361,9 +361,9 @@ spec:
                     type: string
                 type: object
               model:
-                default: claude-sonnet-4-20250514
-                description: model is the AI model to use (e.g., "claude-sonnet-4-20250514",
-                  "claude-haiku-35-20241022").
+                default: openrouter/deepseek/deepseek-v3.2
+                description: model is the AI model to use (e.g., "openrouter/deepseek/deepseek-v3.2",
+                  "claude-sonnet-4-20250514").
                 type: string
               nats:
                 description: nats configures the knight's NATS JetStream consumer

--- a/config/crd/bases/ai.roundtable.io_missions.yaml
+++ b/config/crd/bases/ai.roundtable.io_missions.yaml
@@ -560,9 +560,9 @@ spec:
                               type: string
                           type: object
                         model:
-                          default: claude-sonnet-4-20250514
-                          description: model is the AI model to use (e.g., "claude-sonnet-4-20250514",
-                            "claude-haiku-35-20241022").
+                          default: openrouter/deepseek/deepseek-v3.2
+                          description: model is the AI model to use (e.g., "openrouter/deepseek/deepseek-v3.2",
+                            "claude-sonnet-4-20250514").
                           type: string
                         nats:
                           description: nats configures the knight's NATS JetStream
@@ -1332,9 +1332,9 @@ spec:
                               type: string
                           type: object
                         model:
-                          default: claude-sonnet-4-20250514
-                          description: model is the AI model to use (e.g., "claude-sonnet-4-20250514",
-                            "claude-haiku-35-20241022").
+                          default: openrouter/deepseek/deepseek-v3.2
+                          description: model is the AI model to use (e.g., "openrouter/deepseek/deepseek-v3.2",
+                            "claude-sonnet-4-20250514").
                           type: string
                         nats:
                           description: nats configures the knight's NATS JetStream
@@ -1863,9 +1863,9 @@ spec:
                               type: string
                           type: object
                         model:
-                          default: claude-sonnet-4-20250514
-                          description: model is the AI model to use (e.g., "claude-sonnet-4-20250514",
-                            "claude-haiku-35-20241022").
+                          default: openrouter/deepseek/deepseek-v3.2
+                          description: model is the AI model to use (e.g., "openrouter/deepseek/deepseek-v3.2",
+                            "claude-sonnet-4-20250514").
                           type: string
                         nats:
                           description: nats configures the knight's NATS JetStream
@@ -2654,9 +2654,9 @@ spec:
                             type: string
                         type: object
                       model:
-                        default: claude-sonnet-4-20250514
-                        description: model is the AI model to use (e.g., "claude-sonnet-4-20250514",
-                          "claude-haiku-35-20241022").
+                        default: openrouter/deepseek/deepseek-v3.2
+                        description: model is the AI model to use (e.g., "openrouter/deepseek/deepseek-v3.2",
+                          "claude-sonnet-4-20250514").
                         type: string
                       nats:
                         description: nats configures the knight's NATS JetStream consumer

--- a/config/crd/bases/ai.roundtable.io_roundtables.yaml
+++ b/config/crd/bases/ai.roundtable.io_roundtables.yaml
@@ -492,9 +492,9 @@ spec:
                           type: string
                       type: object
                     model:
-                      default: claude-sonnet-4-20250514
-                      description: model is the AI model to use (e.g., "claude-sonnet-4-20250514",
-                        "claude-haiku-35-20241022").
+                      default: openrouter/deepseek/deepseek-v3.2
+                      description: model is the AI model to use (e.g., "openrouter/deepseek/deepseek-v3.2",
+                        "claude-sonnet-4-20250514").
                       type: string
                     nats:
                       description: nats configures the knight's NATS JetStream consumer
@@ -1179,9 +1179,9 @@ spec:
                             type: string
                         type: object
                       model:
-                        default: claude-sonnet-4-20250514
-                        description: model is the AI model to use (e.g., "claude-sonnet-4-20250514",
-                          "claude-haiku-35-20241022").
+                        default: openrouter/deepseek/deepseek-v3.2
+                        description: model is the AI model to use (e.g., "openrouter/deepseek/deepseek-v3.2",
+                          "claude-sonnet-4-20250514").
                         type: string
                       nats:
                         description: nats configures the knight's NATS JetStream consumer

--- a/internal/controller/mission_briefing_test.go
+++ b/internal/controller/mission_briefing_test.go
@@ -24,10 +24,10 @@ import (
 	"sync"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/go-logr/logr"
 	"github.com/nats-io/nats.go"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 
@@ -57,9 +57,9 @@ func (f *fakeNATSClient) subjects() []string {
 	return out
 }
 
-func (f *fakeNATSClient) Connect() error     { return nil }
-func (f *fakeNATSClient) Close() error       { return nil }
-func (f *fakeNATSClient) IsConnected() bool  { return true }
+func (f *fakeNATSClient) Connect() error    { return nil }
+func (f *fakeNATSClient) Close() error      { return nil }
+func (f *fakeNATSClient) IsConnected() bool { return true }
 
 func (f *fakeNATSClient) Publish(subject string, data []byte) error {
 	if f.failSubject != nil && f.failSubject(subject) {
@@ -96,8 +96,8 @@ func (f *fakeNATSClient) KVPut(string, string, []byte) error { return nil }
 func (f *fakeNATSClient) KVGet(string, string) ([]byte, error) {
 	return nil, fmt.Errorf("not found")
 }
-func (f *fakeNATSClient) KVDelete(string, string) error    { return nil }
-func (f *fakeNATSClient) KVKeys(string) ([]string, error)  { return nil, nil }
+func (f *fakeNATSClient) KVDelete(string, string) error   { return nil }
+func (f *fakeNATSClient) KVKeys(string) ([]string, error) { return nil, nil }
 
 var _ = Describe("MissionReconciler.publishBriefing", func() {
 	const namespace = "default"

--- a/internal/mission/assembler.go
+++ b/internal/mission/assembler.go
@@ -738,7 +738,7 @@ func (a *KnightAssembler) BuildEphemeralRoundTable(
 		rt.Spec.Defaults = parentDefaults
 	} else {
 		rt.Spec.Defaults = &aiv1alpha1.RoundTableDefaults{
-			Model:       "claude-sonnet-4-20250514",
+			Model:       "openrouter/deepseek/deepseek-v3.2",
 			Concurrency: 3,
 			TaskTimeout: 300,
 		}


### PR DESCRIPTION
Closes the last item of today's model-default directive (workspace doc §4, CRD default model).

- `knight_types.go`: `spec.model` kubebuilder default `claude-sonnet-4-20250514` → `openrouter/deepseek/deepseek-v3.2` (CRDs regenerated, chart `crds/` synced).
- `internal/mission/assembler.go`: ephemeral RoundTable fallback defaults get the same treatment.
- **Not** changed: the planner knight's model in `values.yaml` — plan quality gates every meta-mission and it's one session per mission, so sonnet stays until deliberately revisited. The commented example knight in values.yaml now shows the cheap model so it doesn't teach the expensive default.
- Chart version 0.12.3 → **0.13.0** so the CRD change ships as a chart release (image+chart bump in dapper-cluster picks it up).

Effective-behavior note: knights created via the base template are unaffected (template already specifies the model); this only changes what a bare Knight CR with no model gets.

Tests: full `mise run operator:test` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)