### PR TITLE
fix: ephemeral knight assembly — inject RoundTable secrets, exact task subject

### DIFF
--- a/internal/mission/assembler.go
+++ b/internal/mission/assembler.go
@@ -20,6 +20,7 @@ import (
 
 	aiv1alpha1 "github.com/dapperdivers/roundtable/api/v1alpha1"
 	"github.com/dapperdivers/roundtable/internal/status"
+	natspkg "github.com/dapperdivers/roundtable/pkg/nats"
 )
 
 // KnightAssembler handles knight assembly and provisioning for missions.
@@ -445,6 +446,22 @@ func (a *KnightAssembler) applySpecOverrides(
 	}
 }
 
+// appendSecretEnvFrom adds a secret-backed EnvFrom source to a KnightSpec,
+// skipping secrets already referenced (template, RoundTable, and mission
+// lists may overlap).
+func appendSecretEnvFrom(spec *aiv1alpha1.KnightSpec, secretRef corev1.LocalObjectReference) {
+	for _, existing := range spec.EnvFrom {
+		if existing.SecretRef != nil && existing.SecretRef.Name == secretRef.Name {
+			return
+		}
+	}
+	spec.EnvFrom = append(spec.EnvFrom, corev1.EnvFromSource{
+		SecretRef: &corev1.SecretEnvSource{
+			LocalObjectReference: secretRef,
+		},
+	})
+}
+
 // buildEphemeralKnight creates a Knight CR for an ephemeral mission knight.
 func (a *KnightAssembler) buildEphemeralKnight(
 	ctx context.Context,
@@ -461,28 +478,30 @@ func (a *KnightAssembler) buildEphemeralKnight(
 	// Generate knight name
 	knightName := fmt.Sprintf("%s-%s", mission.Name, mk.Name)
 
-	// Override NATS config to point at mission streams
+	// Override NATS config to point at mission streams. Subscribe to this
+	// knight's exact task subject (chains dispatch via TaskSubject to
+	// {prefix}.tasks.{domain}.{knightName}); a domain wildcard would replay
+	// retained tasks from other missions in the same domain.
 	natsPrefix := rt.Spec.NATS.SubjectPrefix
 	spec.NATS = aiv1alpha1.KnightNATS{
 		URL:           rt.Spec.NATS.URL,
 		Stream:        rt.Spec.NATS.TasksStream,
 		ResultsStream: rt.Spec.NATS.ResultsStream,
 		Subjects: []string{
-			fmt.Sprintf("%s.tasks.%s.>", natsPrefix, spec.Domain),
+			natspkg.TaskSubject(natsPrefix, spec.Domain, knightName),
 		},
 		ConsumerName: fmt.Sprintf("msn-%s-%s", mission.Name, mk.Name),
 		MaxDeliver:   1, // Exactly-once delivery for mission tasks
 	}
 
-	// Inject mission secrets (if any)
-	if len(mission.Spec.Secrets) > 0 {
-		for _, secretRef := range mission.Spec.Secrets {
-			spec.EnvFrom = append(spec.EnvFrom, corev1.EnvFromSource{
-				SecretRef: &corev1.SecretEnvSource{
-					LocalObjectReference: secretRef,
-				},
-			})
-		}
+	// Inject RoundTable-shared secrets, then mission-specific ones. Warm
+	// knights reference these secrets in their own manifests; ephemeral
+	// knights only get what we inject here (model API keys live in these).
+	for _, secretRef := range rt.Spec.Secrets {
+		appendSecretEnvFrom(spec, secretRef)
+	}
+	for _, secretRef := range mission.Spec.Secrets {
+		appendSecretEnvFrom(spec, secretRef)
 	}
 
 	// Ephemeral knights don't get persistent workspace

--- a/internal/mission/assembler_test.go
+++ b/internal/mission/assembler_test.go
@@ -1,0 +1,120 @@
+package mission
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	aiv1alpha1 "github.com/dapperdivers/roundtable/api/v1alpha1"
+)
+
+// ─── buildEphemeralKnight ───────────────────────────────────────────────────
+
+func ephemeralFixtures() (*aiv1alpha1.Mission, aiv1alpha1.MissionKnight, *aiv1alpha1.RoundTable) {
+	rt := &aiv1alpha1.RoundTable{
+		ObjectMeta: metav1.ObjectMeta{Name: "personal", Namespace: "roundtable"},
+		Spec: aiv1alpha1.RoundTableSpec{
+			NATS: aiv1alpha1.RoundTableNATS{
+				URL:           "nats://nats.database.svc:4222",
+				SubjectPrefix: "fleet-a",
+				TasksStream:   "fleet_a_tasks",
+				ResultsStream: "fleet_a_results",
+			},
+			KnightTemplates: map[string]aiv1alpha1.KnightSpec{
+				"base": {
+					Model:  "openrouter/deepseek/deepseek-v3.2",
+					Domain: "general",
+				},
+			},
+		},
+	}
+	mission := &aiv1alpha1.Mission{
+		ObjectMeta: metav1.ObjectMeta{Name: "itertest", Namespace: "roundtable"},
+		Spec:       aiv1alpha1.MissionSpec{RoundTableRef: "personal"},
+	}
+	mk := aiv1alpha1.MissionKnight{
+		Name:        "haiku-writer",
+		Ephemeral:   true,
+		TemplateRef: "base",
+		SpecOverrides: &aiv1alpha1.KnightSpecOverrides{
+			Domain: "creative",
+		},
+	}
+	return mission, mk, rt
+}
+
+func TestBuildEphemeralKnightSubscribesToExactSubject(t *testing.T) {
+	mission, mk, rt := ephemeralFixtures()
+	a := &KnightAssembler{}
+
+	knight, err := a.buildEphemeralKnight(context.Background(), mission, mk, rt)
+	if err != nil {
+		t.Fatalf("buildEphemeralKnight: %v", err)
+	}
+
+	want := "fleet-a.tasks.creative.itertest-haiku-writer"
+	if len(knight.Spec.NATS.Subjects) != 1 || knight.Spec.NATS.Subjects[0] != want {
+		t.Errorf("subjects = %v, want [%s] (a domain wildcard replays other missions' retained tasks)",
+			knight.Spec.NATS.Subjects, want)
+	}
+}
+
+func TestBuildEphemeralKnightInjectsRoundTableAndMissionSecrets(t *testing.T) {
+	mission, mk, rt := ephemeralFixtures()
+	rt.Spec.Secrets = []corev1.LocalObjectReference{{Name: "roundtable-secret"}}
+	mission.Spec.Secrets = []corev1.LocalObjectReference{{Name: "mission-extra"}}
+	a := &KnightAssembler{}
+
+	knight, err := a.buildEphemeralKnight(context.Background(), mission, mk, rt)
+	if err != nil {
+		t.Fatalf("buildEphemeralKnight: %v", err)
+	}
+
+	var got []string
+	for _, ef := range knight.Spec.EnvFrom {
+		if ef.SecretRef != nil {
+			got = append(got, ef.SecretRef.Name)
+		}
+	}
+	want := []string{"roundtable-secret", "mission-extra"}
+	if len(got) != len(want) {
+		t.Fatalf("envFrom secrets = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("envFrom[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestBuildEphemeralKnightDedupesSecrets(t *testing.T) {
+	mission, mk, rt := ephemeralFixtures()
+	// Template already carries the secret, and RT + mission list it again.
+	tmpl := rt.Spec.KnightTemplates["base"]
+	tmpl.EnvFrom = []corev1.EnvFromSource{{
+		SecretRef: &corev1.SecretEnvSource{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "roundtable-secret"},
+		},
+	}}
+	rt.Spec.KnightTemplates["base"] = tmpl
+	rt.Spec.Secrets = []corev1.LocalObjectReference{{Name: "roundtable-secret"}}
+	mission.Spec.Secrets = []corev1.LocalObjectReference{{Name: "roundtable-secret"}}
+	a := &KnightAssembler{}
+
+	knight, err := a.buildEphemeralKnight(context.Background(), mission, mk, rt)
+	if err != nil {
+		t.Fatalf("buildEphemeralKnight: %v", err)
+	}
+
+	count := 0
+	for _, ef := range knight.Spec.EnvFrom {
+		if ef.SecretRef != nil && ef.SecretRef.Name == "roundtable-secret" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("roundtable-secret referenced %d times in envFrom, want 1", count)
+	}
+}


### PR DESCRIPTION
## What

Two fixes in `buildEphemeralKnight` (internal/mission/assembler.go), both root-caused live on 2026-07-05 with the `itertest-2026-07-05` meta-mission — the first failing mission to run on a pi-knight#37 runtime, which finally surfaced the real error behind the "Agent produced no deliverable output" failures.

### 1. Wire `RoundTable.Spec.Secrets` into ephemeral knights (the deliverable bug)

The field is documented as "shared secrets available to all knights in this table" but was never referenced anywhere in the operator. Ephemeral knights only got `mission.Spec.Secrets` (which nothing sets), so planner-generated knights had **no `envFrom` at all** → no `OPENROUTER_API_KEY` → every LLM call failed with `401 Missing Authentication header`. Warm knights never hit this because their dapper-cluster manifests carry `envFrom: secretRef: roundtable-secret` directly.

Now: `rt.Spec.Secrets` is injected first, then `mission.Spec.Secrets`, deduped against anything the resolved knight template already references.

**Cluster follow-up (separate dapper-cluster PR, not this repo):** set `spec.secrets: [roundtable-secret]` on the RoundTables (or add `envFrom` to the `base` knightTemplate) — without one of those this fix has nothing to inject.

### 2. Subscribe ephemeral knights to their exact task subject

Chains dispatch to `{prefix}.tasks.{domain}.{knightName}` (`TaskSubject`), but ephemeral knights subscribed to `{prefix}.tasks.{domain}.>`. Observed consequence: the itertest knight's fresh durable consumer replayed **two stale July-4 tasks** from other missions before its own task; concurrent same-domain missions would steal each other's tasks. Briefing publishes skip ephemeral knights, so nothing needed the wildcard.

## Evidence

Captured pod logs from the failing knight (mission cleanup deletes pods in seconds; logs were tailed to disk before dispatch):

```
"msg":"Task produced no deliverable","error":"LLM call failed: 401 Missing Authentication header",
"sessionTail":[{"role":"user","parts":{"text":1}},{"role":"assistant","stopReason":"error","errorMessage":"401 Missing Authentication header","parts":{}}]
```

Same pod, before its own task arrived — stale cross-mission consumption:
```
"Task received","taskId":"chain-mission-live-test-fable-haiku-generation-...","subject":"fleet-a.tasks.creative.live-test-fable-poet-knight"
"Task received","taskId":"chain-mission-live-test-postdeploy2-turtle-haiku-chain-...","subject":"fleet-a.tasks.creative.live-test-postdeploy2-poet-scribe"
```

Warm knight (agravain, has the secret via its manifest) answered a dispatch on the same OpenRouter model fine ($0.0013, 2.1s).

## Tests

- `TestBuildEphemeralKnightSubscribesToExactSubject`
- `TestBuildEphemeralKnightInjectsRoundTableAndMissionSecrets`
- `TestBuildEphemeralKnightDedupesSecrets`

`mise run operator:test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)