### PR TITLE
chore: pin pi-knight f2ab01a in chart values, bump chart 0.13.1

### DIFF
--- a/charts/roundtable-operator/Chart.yaml
+++ b/charts/roundtable-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: roundtable-operator
 description: Knights of the Round Table — A Kubernetes Operator for Multi-Agent AI Orchestration
 type: application
-version: 0.13.0
+version: 0.13.1
 appVersion: "1.0.0"
 keywords:
   - ai

--- a/charts/roundtable-operator/values.yaml
+++ b/charts/roundtable-operator/values.yaml
@@ -36,7 +36,7 @@ extraArgs: []
 images:
   piKnight:
     repository: ghcr.io/dapperdivers/pi-knight
-    tag: fb42daedc97e845b049a2855a78d731b125d80d9
+    tag: f2ab01a9c2a5a0f215bf8c996f7c689aceee085c
   dashboard:
     repository: ghcr.io/dapperdivers/roundtable-ui
     tag: 630f8dfc80532139211896a67f3c9635aa0928b0


### PR DESCRIPTION
Re-pins pi-knight `fb42dae` → `f2ab01a` in the chart values and bumps the chart `0.13.0` → `0.13.1` so the new runtime deploys via the usual chart-version bump.

Ships:
- **pi-knight#38** — pre-warm the agent session at startup; adopt the warm session on the first chain run (cuts cold-start).
- **pi-knight#39** — degraded 503 state instead of fatal crash-loop on preflight failure; in-process retry with capped backoff.

Operator-only change #140 rides separately via the helmrelease image tag. Next step: dapper-cluster bump (operator `73debdb` + chart `0.13.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)