### PR TITLE
fix: meta-mission marked Failed despite chain succeeding (source chain not found)

### DIFF
--- a/internal/controller/mission_controller.go
+++ b/internal/controller/mission_controller.go
@@ -1181,19 +1181,15 @@ func (r *MissionReconciler) aggregateMissionCost(ctx context.Context, mission *a
 func (r *MissionReconciler) ensureMissionChain(ctx context.Context, mission *aiv1alpha1.Mission, chainRef aiv1alpha1.MissionChainRef) error {
 	log := logf.FromContext(ctx)
 
-	// Fetch the source chain template
-	sourceChain := &aiv1alpha1.Chain{}
-	if err := r.Get(ctx, types.NamespacedName{
-		Name:      chainRef.Name,
-		Namespace: mission.Namespace,
-	}, sourceChain); err != nil {
-		return fmt.Errorf("source chain %q not found: %w", chainRef.Name, err)
-	}
-
 	// Build the mission-scoped chain name
 	missionChainName := fmt.Sprintf("mission-%s-%s", mission.Name, chainRef.Name)
 
-	// Check if it already exists
+	// If the mission-scoped chain already exists, there is nothing to do.
+	// Meta-mission chains are created directly by the planner (applyPlan), so
+	// there is no standalone source-chain template to copy from — this
+	// short-circuits before the source lookup below, which would otherwise
+	// fail with "source chain not found" and mark the mission Failed even
+	// though its chain ran successfully.
 	existingChain := &aiv1alpha1.Chain{}
 	err := r.Get(ctx, types.NamespacedName{
 		Name:      missionChainName,
@@ -1205,6 +1201,15 @@ func (r *MissionReconciler) ensureMissionChain(ctx context.Context, mission *aiv
 	}
 	if client.IgnoreNotFound(err) != nil {
 		return err
+	}
+
+	// Fetch the source chain template (template-based missions only)
+	sourceChain := &aiv1alpha1.Chain{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      chainRef.Name,
+		Namespace: mission.Namespace,
+	}, sourceChain); err != nil {
+		return fmt.Errorf("source chain %q not found: %w", chainRef.Name, err)
 	}
 
 	// Get RoundTable reference for this mission

--- a/internal/controller/mission_controller_test.go
+++ b/internal/controller/mission_controller_test.go
@@ -2109,5 +2109,45 @@ var _ = Describe("Mission Controller - Generated Chains", func() {
 			Expect(chain.Spec.MissionRef).To(Equal(missionName),
 				"Planner-generated chain should have missionRef set")
 		})
+
+		It("ensureMissionChain is a no-op when the planner already created the chain (no source template)", func() {
+			// Regression: meta-mission chains are created directly by the planner
+			// as mission-<mission>-<chain>; there is no standalone source-chain
+			// template. ensureMissionChain must short-circuit on the existing
+			// chain instead of failing with "source chain not found" (which
+			// marked the mission Failed even though its chain succeeded).
+			mission := &aiv1alpha1.Mission{
+				ObjectMeta: metav1.ObjectMeta{Name: missionName, Namespace: namespace},
+				Spec: aiv1alpha1.MissionSpec{
+					Objective:     "Test meta-mission chain wiring",
+					RoundTableRef: rtName,
+				},
+			}
+
+			By("Pre-creating the mission-scoped chain as the planner would")
+			missionChainName := fmt.Sprintf("mission-%s-haiku-generation", missionName)
+			plannerChain := &aiv1alpha1.Chain{
+				ObjectMeta: metav1.ObjectMeta{Name: missionChainName, Namespace: namespace},
+				Spec: aiv1alpha1.ChainSpec{
+					Description:   "Planner-created chain",
+					Steps:         []aiv1alpha1.ChainStep{{Name: "write_haiku", KnightRef: "haiku-writer", Task: "Write a haiku"}},
+					MissionRef:    missionName,
+					RoundTableRef: rtName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, plannerChain)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, plannerChain) }()
+
+			By("Calling ensureMissionChain with only the bare chain name and no source template")
+			reconciler := &MissionReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: record.NewFakeRecorder(100),
+			}
+			err := reconciler.ensureMissionChain(ctx, mission,
+				aiv1alpha1.MissionChainRef{Name: "haiku-generation", Phase: "Active"})
+			Expect(err).NotTo(HaveOccurred(),
+				"should short-circuit on the existing planner chain, not require a source template")
+		})
 	})
 })


### PR DESCRIPTION
Found in the post-bump verification once the ephemeral-knight 401 was fixed: a meta-mission's generated chain reached `Succeeded` (knight authenticated, deepseek produced the haiku, result parsed) — yet the **mission** reported `Failed`.

**Root cause:** `ensureMissionChain` fetched the source-chain *template* by the bare name (`haiku-generation`) **before** checking whether the mission-scoped chain already existed. Meta-mission chains are created directly by the planner (`applyPlan`) as `mission-<mission>-<chain>` — there's no standalone template — so the lookup failed `source chain "haiku-generation" not found`, the mission was marked Failed, and its real (prefixed) chain succeeded ~30s later, ignored.

**Fix:** reorder so the existing mission-scoped chain short-circuits first; only fall through to the template copy for template-based missions. Regression test added (`ensureMissionChain` no-op when the planner already created the chain, no source template). `mise run operator:test` green.

This is the last blocker for closing known-issue #1 — with the 401 fix already deployed, a fresh meta-mission should now reach Succeeded end-to-end. Operator-only change; deploys via the helmrelease image tag (no chart bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)