### PR TITLE
chore(chart): bump dashboard image to 6332301 (NATS reconnect fix)

### DIFF
--- a/charts/roundtable-operator/Chart.yaml
+++ b/charts/roundtable-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: roundtable-operator
 description: Knights of the Round Table — A Kubernetes Operator for Multi-Agent AI Orchestration
 type: application
-version: 0.14.0
+version: 0.14.1
 appVersion: "1.0.0"
 keywords:
   - ai

--- a/charts/roundtable-operator/values.yaml
+++ b/charts/roundtable-operator/values.yaml
@@ -49,7 +49,7 @@ images:
     tag: f2ab01a9c2a5a0f215bf8c996f7c689aceee085c
   dashboard:
     repository: ghcr.io/dapperdivers/roundtable-ui
-    tag: 630f8dfc80532139211896a67f3c9635aa0928b0
+    tag: 6332301c63944ea6ccd87b63e08ac94182a8793b
 
 # Pod-level security context for all knight-owned pods — knight Deployments
 # AND the shared Nix store build Jobs. Set once here; the operator applies it


### PR DESCRIPTION
Bumps the dashboard image pin to `6332301` and the chart to `0.14.1`, shipping [roundtable-ui#147](https://github.com/dapperdivers/roundtable-ui/pull/147).

That PR makes the dashboard API reconnect to NATS forever (`MaxReconnects(-1)` + jittered backoff) instead of giving up after ~2 min and permanently closing — the failure that was flapping the live-feed 🟢/🔴 indicator and 500/504ing the NATS-backed endpoints. Also rejects the WS upgrade with 503 when NATS is down (kills the connected/disconnected flicker) and surfaces the close reason for diagnosis.

- `charts/roundtable-operator/values.yaml`: `images.dashboard.tag` `630f8df` → `6332301`
- `charts/roundtable-operator/Chart.yaml`: `0.14.0` → `0.14.1`

Once merged + chart published, the dapper-cluster helmrelease chart version gets bumped to `0.14.1` to roll it out.