### PR TITLE
chore(chart): bump dashboard image to 12be217 (session explorer legibility)

### DIFF
--- a/charts/roundtable-operator/Chart.yaml
+++ b/charts/roundtable-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: roundtable-operator
 description: Knights of the Round Table — A Kubernetes Operator for Multi-Agent AI Orchestration
 type: application
-version: 0.14.1
+version: 0.14.2
 appVersion: "1.0.0"
 keywords:
   - ai

--- a/charts/roundtable-operator/values.yaml
+++ b/charts/roundtable-operator/values.yaml
@@ -49,7 +49,7 @@ images:
     tag: f2ab01a9c2a5a0f215bf8c996f7c689aceee085c
   dashboard:
     repository: ghcr.io/dapperdivers/roundtable-ui
-    tag: 6332301c63944ea6ccd87b63e08ac94182a8793b
+    tag: 12be217a8f6688f803a40ea3dbb5650a7091fe55
 
 # Pod-level security context for all knight-owned pods — knight Deployments
 # AND the shared Nix store build Jobs. Set once here; the operator applies it


### PR DESCRIPTION
Bumps the dashboard (roundtable-ui) image pinned in the chart to `12be217` —
the Session Explorer legibility fix (dapperdivers/roundtable-ui#148): capped
tree indentation so long parent→child chains stop marching off-screen, pinned
non-wrapping timestamps, and role-aware timeline labels so message entries no
longer render as a bare "message".

- `charts/roundtable-operator/values.yaml`: `images.dashboard.tag` 6332301 → 12be217
- `charts/roundtable-operator/Chart.yaml`: 0.14.1 → 0.14.2 (dashboard image only; operator/pi-knight pins unchanged)

Deploy: after merge + chart publish, bump the helmrelease chart version to 0.14.2 in dapper-cluster.