### PR TITLE
chore(chart): bump pi-knight to 4d747ff (introspect message content)

### DIFF
--- a/charts/roundtable-operator/Chart.yaml
+++ b/charts/roundtable-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: roundtable-operator
 description: Knights of the Round Table — A Kubernetes Operator for Multi-Agent AI Orchestration
 type: application
-version: 0.14.2
+version: 0.14.3
 appVersion: "1.0.0"
 keywords:
   - ai

--- a/charts/roundtable-operator/values.yaml
+++ b/charts/roundtable-operator/values.yaml
@@ -46,7 +46,7 @@ notify:
 images:
   piKnight:
     repository: ghcr.io/dapperdivers/pi-knight
-    tag: f2ab01a9c2a5a0f215bf8c996f7c689aceee085c
+    tag: 4d747ff6a701e8b27897bf96f70902a442debc3e
   dashboard:
     repository: ghcr.io/dapperdivers/roundtable-ui
     tag: 12be217a8f6688f803a40ea3dbb5650a7091fe55


### PR DESCRIPTION
Bumps the pi-knight image pinned in the chart to `4d747ff` — the session
introspect fix (pi-knight#40) that extracts real message content (tool results,
assistant tool calls, correct token/cost) so the Session Explorer timeline shows
actual data instead of empty rows.

- `charts/roundtable-operator/values.yaml`: `images.piKnight.tag` f2ab01a → 4d747ff
- `charts/roundtable-operator/Chart.yaml`: 0.14.2 → 0.14.3 (pi-knight image only; operator/dashboard pins unchanged)

Deploy: after merge + chart publish, bump the helmrelease chart version to 0.14.3 in dapper-cluster.