### PR TITLE
chore(chart): session history/replay — pi-knight a220890 + dashboard 5d8702f, chart 0.14.4

### DIFF
--- a/charts/roundtable-operator/Chart.yaml
+++ b/charts/roundtable-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: roundtable-operator
 description: Knights of the Round Table — A Kubernetes Operator for Multi-Agent AI Orchestration
 type: application
-version: 0.14.3
+version: 0.14.4
 appVersion: "1.0.0"
 keywords:
   - ai

--- a/charts/roundtable-operator/values.yaml
+++ b/charts/roundtable-operator/values.yaml
@@ -46,10 +46,10 @@ notify:
 images:
   piKnight:
     repository: ghcr.io/dapperdivers/pi-knight
-    tag: 4d747ff6a701e8b27897bf96f70902a442debc3e
+    tag: a220890c7271135da415d7ebfabe9b08df2a711b
   dashboard:
     repository: ghcr.io/dapperdivers/roundtable-ui
-    tag: 12be217a8f6688f803a40ea3dbb5650a7091fe55
+    tag: 5d8702fa9e45701834b516e45e6bf020bb5a1d07
 
 # Pod-level security context for all knight-owned pods — knight Deployments
 # AND the shared Nix store build Jobs. Set once here; the operator applies it


### PR DESCRIPTION
Bumps both images for the session history/replay feature and cuts chart 0.14.4:

- `images.piKnight.tag` 4d747ff → a220890 — introspect history/session types (pi-knight#41)
- `images.dashboard.tag` 12be217 → 5d8702f — Session Explorer session picker + API passthrough (roundtable-ui#149)
- `Chart.yaml` 0.14.3 → 0.14.4

Deploy: after merge + chart publish, bump the helmrelease chart version to 0.14.4 in dapper-cluster.